### PR TITLE
Update port references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 
 # Server Configuration
 NODE_ENV=development
-PORT=5000
+PORT=5006
 
 # Session Security
 SESSION_SECRET=your-secure-session-secret-here

--- a/.replit
+++ b/.replit
@@ -12,7 +12,7 @@ build = ["npm", "run", "build"]
 run = ["npm", "run", "start"]
 
 [[ports]]
-localPort = 5000
+localPort = 5006
 externalPort = 80
 
 [workflows]
@@ -34,4 +34,4 @@ author = "agent"
 [[workflows.workflow.tasks]]
 task = "shell.exec"
 args = "npm run dev"
-waitForPort = 5000
+waitForPort = 5006

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ A sleek, full-stack web application for monitoring and managing Raspberry Pi ser
    ```
 
 4. **Access the dashboard**
-   - Open http://localhost:5000
+   - Open http://localhost:5006
    - Login with password: `admin`
 
 ## 📖 Usage

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,7 +5,7 @@ RESTful API documentation for PiDeck admin dashboard backend.
 ## Base URL
 
 ```
-http://localhost:5000/api
+http://localhost:5006/api
 ```
 
 ## Authentication
@@ -113,7 +113,7 @@ GET /api/logs/{filename}
 **Response:**
 ```json
 {
-  "content": "2025-06-20 12:30:15 INFO Application started\n2025-06-20 12:30:16 INFO Server listening on port 5000\n..."
+  "content": "2025-06-20 12:30:15 INFO Application started\n2025-06-20 12:30:16 INFO Server listening on port 5006\n..."
 }
 ```
 
@@ -327,7 +327,7 @@ Future versions may include WebSocket support for real-time updates:
 
 ```javascript
 // Example WebSocket connection
-const ws = new WebSocket('ws://localhost:5000/api/ws');
+const ws = new WebSocket('ws://localhost:5006/api/ws');
 
 ws.on('system-update', (data) => {
   console.log('System metrics updated:', data);
@@ -339,7 +339,7 @@ ws.on('system-update', (data) => {
 ### JavaScript/Node.js
 ```javascript
 class PiDeckAPI {
-  constructor(baseURL = 'http://localhost:5000/api') {
+  constructor(baseURL = 'http://localhost:5006/api') {
     this.baseURL = baseURL;
     this.sessionCookie = null;
   }
@@ -376,7 +376,7 @@ class PiDeckAPI {
 import requests
 
 class PiDeckAPI:
-    def __init__(self, base_url='http://localhost:5000/api'):
+    def __init__(self, base_url='http://localhost:5006/api'):
         self.base_url = base_url
         self.session = requests.Session()
 
@@ -397,16 +397,16 @@ class PiDeckAPI:
 ### cURL Examples
 ```bash
 # Login
-curl -X POST http://localhost:5000/api/auth/login \
+curl -X POST http://localhost:5006/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"password": "admin"}' \
   -c cookies.txt
 
 # Get system info
-curl -X GET http://localhost:5000/api/system/info \
+curl -X GET http://localhost:5006/api/system/info \
   -b cookies.txt
 
 # Restart container
-curl -X POST http://localhost:5000/api/docker/containers/abc123/restart \
+curl -X POST http://localhost:5006/api/docker/containers/abc123/restart \
   -b cookies.txt
 ```

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -11,7 +11,7 @@ npm install
 npm run dev
 ```
 
-Access at http://localhost:5000 with password: `admin`
+Access at http://localhost:5006 with password: `admin`
 
 ## Production on Raspberry Pi
 
@@ -60,7 +60,7 @@ server {
     server_name your-domain.com;
 
     location / {
-        proxy_pass http://localhost:5000;
+        proxy_pass http://localhost:5006;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -94,7 +94,7 @@ docker build -t pideck .
 # Run container
 docker run -d \
   --name pideck \
-  -p 5000:5000 \
+  -p 5006:5006 \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /home/zk/logs:/home/zk/logs \
   pideck
@@ -105,7 +105,7 @@ docker run -d \
 Create `.env` file:
 ```bash
 NODE_ENV=production
-PORT=5000
+PORT=5006
 SESSION_SECRET=your-secure-secret-here
 ```
 
@@ -123,7 +123,7 @@ Check application status:
 ```bash
 pm2 status
 pm2 logs pideck
-curl http://localhost:5000/api/auth/me
+curl http://localhost:5006/api/auth/me
 ```
 
 For detailed installation instructions, see [docs/INSTALL.md](./INSTALL.md)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -95,7 +95,7 @@ Create environment file (optional):
 # Create .env file
 cat > .env << EOF
 NODE_ENV=development
-PORT=5000
+PORT=5006
 SESSION_SECRET=your-secure-session-secret-here
 EOF
 ```
@@ -117,11 +117,11 @@ echo "Another log entry $(date)" > /home/zk/logs/app.log
 npm run dev
 
 # The application will be available at:
-# http://localhost:5000
+# http://localhost:5006
 ```
 
 ### 6. Access the Dashboard
-1. Open your browser to `http://localhost:5000`
+1. Open your browser to `http://localhost:5006`
 2. Login with password: `admin`
 3. Navigate through the different sections
 
@@ -161,7 +161,7 @@ npm run build
 # Create production environment file
 cat > .env << EOF
 NODE_ENV=production
-PORT=5000
+PORT=5006
 SESSION_SECRET=$(openssl rand -base64 32)
 EOF
 
@@ -214,7 +214,7 @@ server {
 
     # Rate limiting
     location / {
-        proxy_pass http://localhost:5000;
+        proxy_pass http://localhost:5006;
         proxy_http_version 1.1;
         proxy_set_header Upgrade \$http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -271,7 +271,7 @@ Type=simple
 User=pideck
 WorkingDirectory=/home/pideck/PiDeck
 Environment=NODE_ENV=production
-Environment=PORT=5000
+Environment=PORT=5006
 ExecStart=/usr/bin/node dist/index.js
 Restart=always
 RestartSec=10
@@ -358,10 +358,10 @@ sudo chmod +x /usr/local/bin/pideck-backup.sh
 
 ### Common Issues
 
-#### 1. Port 5000 Already in Use
+#### 1. Port 5006 Already in Use
 ```bash
-# Find process using port 5000
-sudo lsof -i :5000
+# Find process using port 5006
+sudo lsof -i :5006
 
 # Kill the process if needed
 sudo kill -9 <PID>
@@ -410,7 +410,7 @@ sudo tail -f /var/log/nginx/error.log
 #### Health Check
 ```bash
 # Check if application is running
-curl http://localhost:5000/api/auth/me
+curl http://localhost:5006/api/auth/me
 
 # Check system resources
 htop


### PR DESCRIPTION
## Summary
- use port 5006 instead of 5000 in `.replit`
- set PORT=5006 in `.env.example`
- update localhost URLs in README quick start
- revise deployment, installation and API docs for new port

## Testing
- `grep -R "5000" -n docs README.md .replit .env.example`

------
https://chatgpt.com/codex/tasks/task_e_6854ebcbd8dc832288004ca9c2713430