### PR TITLE
Add NGINX config example for pideck.piapps.dev

### DIFF
--- a/docs/nginx/README.md
+++ b/docs/nginx/README.md
@@ -1,0 +1,21 @@
+# PiDeck NGINX Configuration
+
+This directory contains an example NGINX site configuration for `pideck.piapps.dev`.
+
+## Enable the Site
+
+Copy the file to `/etc/nginx/sites-available/` and create a symlink in `sites-enabled`:
+
+```bash
+sudo cp docs/nginx/pideck.piapps.dev.conf /etc/nginx/sites-available/pideck.piapps.dev
+sudo ln -s /etc/nginx/sites-available/pideck.piapps.dev /etc/nginx/sites-enabled/
+```
+
+## Test and Reload NGINX
+
+Always verify the configuration before reloading NGINX:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```

--- a/docs/nginx/pideck.piapps.dev.conf
+++ b/docs/nginx/pideck.piapps.dev.conf
@@ -1,0 +1,25 @@
+server {
+    listen 80;
+    server_name pideck.piapps.dev www.pideck.piapps.dev;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name pideck.piapps.dev www.pideck.piapps.dev;
+
+    ssl_certificate /etc/letsencrypt/live/pideck.piapps.dev/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/pideck.piapps.dev/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:5006;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+}


### PR DESCRIPTION
## Summary
- provide example site config for `pideck.piapps.dev`
- document how to enable the site and reload NGINX

## Testing
- `npm run check` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_6854ebcc7e0c8322afea02b5b54340c5