### PR TITLE
Remove duplicate SystemInfo definition

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -26,26 +26,6 @@ export const loginSchema = z.object({
   password: z.string().min(1, "Password is required"),
 });
 
-// System data types
-export type SystemInfo = {
-  hostname: string;
-  os: string;
-  kernel: string;
-  architecture: string;
-  uptime: string;
-  cpu: number;
-  memory: {
-    used: number;
-    total: number;
-    percentage: number;
-  };
-  temperature: number;
-  network: {
-    ip: string;
-    status: string;
-  };
-};
-
 export type LogFile = {
   name: string;
   path: string;


### PR DESCRIPTION
## Summary
- remove redundant `SystemInfo` type definition
- leave only `SystemInfoExtended` and alias `SystemInfo = SystemInfoExtended`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6857345c9a5483228974e0a35ebd2065

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced system information now includes additional details such as disk I/O, network bandwidth, and process information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->