### PR TITLE
Implement dashboard quick actions

### DIFF
--- a/client/src/components/system-overview.tsx
+++ b/client/src/components/system-overview.tsx
@@ -20,7 +20,14 @@ import {
 import { DiskIOGraph, NetworkBandwidthGraph } from "./resource-graphs";
 import ProcessList from "./process-list";
 
-export default function SystemOverview() {
+interface OverviewProps {
+  onOpenApps?: () => void;
+  onOpenLogs?: () => void;
+  onUpdateSystem?: () => void;
+  isSystemUpdating?: boolean;
+}
+
+export default function SystemOverview({ onOpenApps, onOpenLogs, onUpdateSystem, isSystemUpdating }: OverviewProps) {
   const { systemInfo, refreshAll, historicalData } = useSystemData();
 
   if (systemInfo.isLoading || historicalData.isLoading) {
@@ -214,34 +221,35 @@ export default function SystemOverview() {
               <span>Quick Actions</span>
             </h3>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-              <Button 
-                variant="outline" 
+              <Button
+                variant="outline"
                 className="flex flex-col items-center space-y-2 p-4 h-auto bg-pi-darker hover:bg-pi-card-hover border-pi-border"
                 onClick={refreshAll}
               >
                 <RefreshCw className="w-6 h-6 text-pi-accent" />
                 <span className="text-sm pi-text">Refresh Data</span>
               </Button>
-              <Button 
-                variant="outline" 
+              <Button
+                variant="outline"
                 className="flex flex-col items-center space-y-2 p-4 h-auto bg-pi-darker hover:bg-pi-card-hover border-pi-border"
-                disabled
+                onClick={onUpdateSystem}
+                disabled={isSystemUpdating}
               >
-                <Download className="w-6 h-6 text-green-400" />
+                <Download className={`w-6 h-6 text-green-400 ${isSystemUpdating ? 'animate-spin' : ''}`} />
                 <span className="text-sm pi-text">Update System</span>
               </Button>
-              <Button 
-                variant="outline" 
+              <Button
+                variant="outline"
                 className="flex flex-col items-center space-y-2 p-4 h-auto bg-pi-darker hover:bg-pi-card-hover border-pi-border"
-                disabled
+                onClick={onOpenApps}
               >
                 <ListChecks className="w-6 h-6 text-purple-400" />
                 <span className="text-sm pi-text">Manage Apps</span>
               </Button>
-              <Button 
-                variant="outline" 
+              <Button
+                variant="outline"
                 className="flex flex-col items-center space-y-2 p-4 h-auto bg-pi-darker hover:bg-pi-card-hover border-pi-border"
-                disabled
+                onClick={onOpenLogs}
               >
                 <BarChart3 className="w-6 h-6 text-orange-400" />
                 <span className="text-sm pi-text">View Logs</span>

--- a/client/src/hooks/use-system-data.ts
+++ b/client/src/hooks/use-system-data.ts
@@ -92,6 +92,12 @@ export function useSystemData() {
     },
   });
 
+  const updateSystemMutation = useMutation({
+    mutationFn: async () => {
+      return apiRequest("POST", "/api/system/update");
+    },
+  });
+
   const refreshAll = () => {
     queryClient.invalidateQueries({ queryKey: ["/api/system/info"] });
     queryClient.invalidateQueries({ queryKey: ["/api/system/history"] });
@@ -116,10 +122,12 @@ export function useSystemData() {
     restartProcess: restartProcessMutation.mutateAsync,
     stopProcess: stopProcessMutation.mutateAsync,
     runCronJob: runCronJobMutation.mutateAsync,
+    updateSystem: updateSystemMutation.mutateAsync,
     refreshAll,
     isContainerActionPending: restartContainerMutation.isPending || stopContainerMutation.isPending || startContainerMutation.isPending,
     isProcessActionPending: restartProcessMutation.isPending || stopProcessMutation.isPending,
     isCronJobPending: runCronJobMutation.isPending,
+    isSystemUpdating: updateSystemMutation.isPending,
   };
 }
 

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -39,7 +39,7 @@ interface TabDefinition {
 export default function Dashboard() {
   const [activeTab, setActiveTab] = useState<TabId>("dashboard");
   const { logout, isLogoutPending } = useAuth();
-  const { systemInfo, systemAlerts, refreshAll } = useSystemData();
+  const { systemInfo, systemAlerts, refreshAll, updateSystem, isSystemUpdating } = useSystemData();
   const { theme, setTheme } = useTheme();
   const { toast } = useToast();
   const displayedAlertIds = useRef<Set<string>>(new Set());
@@ -72,6 +72,19 @@ export default function Dashboard() {
     await logout();
   };
 
+  const handleUpdateSystem = async () => {
+    try {
+      await updateSystem();
+      toast({ title: "Success", description: "System updated successfully" });
+    } catch (error) {
+      toast({
+        title: "Error",
+        description: "Failed to update system",
+        variant: "destructive",
+      });
+    }
+  };
+
   const toggleTheme = () => {
     setTheme(theme === "dark" ? "light" : "dark");
   };
@@ -88,10 +101,27 @@ export default function Dashboard() {
     const currentTab = tabs.find(tab => tab.id === activeTab);
     if (currentTab) {
       const TabComponent = currentTab.component;
+      if (currentTab.id === 'dashboard') {
+        return (
+          <SystemOverview
+            onOpenApps={() => setActiveTab('apps')}
+            onOpenLogs={() => setActiveTab('logs')}
+            onUpdateSystem={handleUpdateSystem}
+            isSystemUpdating={isSystemUpdating}
+          />
+        );
+      }
       return <TabComponent />;
     }
     // Fallback to dashboard if tab not found, though this shouldn't happen
-    return <SystemOverview />;
+    return (
+      <SystemOverview
+        onOpenApps={() => setActiveTab('apps')}
+        onOpenLogs={() => setActiveTab('logs')}
+        onUpdateSystem={handleUpdateSystem}
+        isSystemUpdating={isSystemUpdating}
+      />
+    );
   };
 
   return (

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -200,6 +200,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.post("/api/system/update", requireAuth, async (_req, res) => {
+    try {
+      const output = await SystemService.updateSystem();
+      res.json({ message: "System updated", output });
+    } catch (error) {
+      console.error("System update error:", error);
+      res.status(500).json({ message: "Failed to update system" });
+    }
+  });
+
   // Log routes
   app.get("/api/logs", requireAuth, async (req, res) => {
     try {

--- a/server/services/system.ts
+++ b/server/services/system.ts
@@ -658,4 +658,16 @@ private static async getNetworkBandwidth(): Promise<NetworkBandwidth> {
       throw new Error("Failed to execute cron job");
     }
   }
+
+  static async updateSystem(): Promise<string> {
+    try {
+      const { stdout, stderr } = await execAsync(
+        "sudo apt-get update && sudo apt-get upgrade -y"
+      );
+      return stdout || stderr;
+    } catch (error) {
+      console.error("Error updating system:", error);
+      throw new Error("System update failed");
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- wire up system update endpoint
- expose system update in client hook
- open Apps/Logs tabs via callbacks
- add quick action buttons for update system, manage apps, and view logs

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685739322de8832282a5eccb9108298c