### PR TITLE
Fix metrics calculations and validation

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -65,10 +65,25 @@ export type DiskIO = {
   utilization: number; // Percentage
 };
 
+export const diskIOSchema = z.object({
+  readSpeed: z.number().int().nonnegative().max(100000),
+  writeSpeed: z.number().int().nonnegative().max(100000),
+  utilization: z.number().int().min(0).max(100),
+});
+
+export type DiskIOData = z.infer<typeof diskIOSchema>;
+
 export type NetworkBandwidth = {
   rx: number; // KB/s
   tx: number; // KB/s
 };
+
+export const networkBandwidthSchema = z.object({
+  rx: z.number().int().nonnegative().max(1000000),
+  tx: z.number().int().nonnegative().max(1000000),
+});
+
+export type NetworkBandwidthData = z.infer<typeof networkBandwidthSchema>;
 
 export type ProcessInfo = {
   pid: number;


### PR DESCRIPTION
## Summary
- import `HistoricalMetric` in system service
- rewrite disk IO and network bandwidth collection for reliability
- return integer values and log for debugging
- add validation schemas for disk IO and network bandwidth

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685743d8116c8322a0e8f4ea3eae014a