### PR TITLE
Add reboot check warning

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -38,11 +38,19 @@ interface TabDefinition {
 
 export default function Dashboard() {
   const [activeTab, setActiveTab] = useState<TabId>("dashboard");
+  const [rebootRequired, setRebootRequired] = useState(false);
   const { logout, isLogoutPending } = useAuth();
   const { systemInfo, systemAlerts, refreshAll, updateSystem, isSystemUpdating } = useSystemData();
   const { theme, setTheme } = useTheme();
   const { toast } = useToast();
   const displayedAlertIds = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    fetch("/api/reboot-check", { credentials: "include" })
+      .then((res) => res.json())
+      .then((data) => setRebootRequired(Boolean(data.rebootRequired)))
+      .catch((err) => console.error("Failed to check reboot status", err));
+  }, []);
 
   useEffect(() => {
     if (systemAlerts.data) {
@@ -195,6 +203,12 @@ export default function Dashboard() {
           </div>
         </div>
       </header>
+
+      {rebootRequired && (
+        <div className="bg-red-700 text-white px-4 py-2 rounded-xl text-center shadow-lg animate-pulse mx-4 mt-4">
+          ⚠️ System reboot required to activate latest kernel updates
+        </div>
+      )}
 
       {/* Main Content */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -210,6 +210,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.get("/api/reboot-check", requireAuth, async (_req, res) => {
+    try {
+      const rebootRequired = await SystemService.checkRebootRequired();
+      res.json({ rebootRequired });
+    } catch (error) {
+      console.error("Reboot check error:", error);
+      res.status(500).json({ message: "Failed to check reboot status" });
+    }
+  });
+
   // Log routes
   app.get("/api/logs", requireAuth, async (req, res) => {
     try {

--- a/server/services/system.ts
+++ b/server/services/system.ts
@@ -592,6 +592,17 @@ private static async getNetworkBandwidth(): Promise<NetworkBandwidth> {
     }
   }
 
+  static async checkRebootRequired(): Promise<boolean> {
+    try {
+      const { stdout } = await execAsync("/home/zk/bin/check-reboot.sh");
+      const result = JSON.parse(stdout.trim());
+      return Boolean(result.reboot_required);
+    } catch (error) {
+      console.error("Error checking reboot requirement:", error);
+      throw new Error("Failed to check reboot status");
+    }
+  }
+
   static async updateSystem(): Promise<string> {
     try {
       const { stdout, stderr } = await execAsync(


### PR DESCRIPTION
## Summary
- run check-reboot.sh from backend and expose `/api/reboot-check`
- call reboot check on dashboard load and show warning badge

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68574eb0e5fc832289ea5941174bea32