### PR TITLE
Add NVMe SMART metrics widget

### DIFF
--- a/client/src/components/system-overview.tsx
+++ b/client/src/components/system-overview.tsx
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import { DiskIOGraph, NetworkBandwidthGraph } from "./resource-graphs";
 import ProcessList from "./process-list";
+import { NvmeHealthBox } from "./widgets/NvmeHealthBox";
 
 interface OverviewProps {
   onOpenApps?: () => void;
@@ -165,6 +166,8 @@ export default function SystemOverview({ onOpenApps, onOpenLogs, onUpdateSystem,
             </div>
           </CardContent>
         </Card>
+
+        <NvmeHealthBox />
       </div>
 
       {/* Resource Graphs */}

--- a/client/src/components/widgets/NvmeHealthBox.tsx
+++ b/client/src/components/widgets/NvmeHealthBox.tsx
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query'
+
+const fetchNvmeHealth = async () => {
+  const res = await fetch('/api/metrics/nvme')
+  if (!res.ok) throw new Error('Failed to fetch')
+  return res.json()
+}
+
+export function NvmeHealthBox() {
+  const { data, error, isLoading } = useQuery({
+    queryKey: ['nvme-health'],
+    queryFn: fetchNvmeHealth,
+    refetchInterval: 10000,
+  })
+
+  return (
+    <div className="rounded-2xl border p-4 shadow bg-[#0f172a] text-white w-full max-w-sm">
+      <h3 className="text-lg font-semibold mb-2">NVMe Status</h3>
+      {isLoading ? (
+        <p>Loading...</p>
+      ) : error || !data ? (
+        <p className="text-red-400">Unavailable</p>
+      ) : (
+        <ul className="space-y-1 text-sm">
+          <li><strong>Temp:</strong> {data.temperature}°C</li>
+          <li><strong>Power-On Hours:</strong> {data.power_on_hours}</li>
+          <li><strong>Wear Leveling:</strong> {data.wear_leveling_count}</li>
+          <li><strong>Media Errors:</strong> {data.media_errors}</li>
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4,6 +4,7 @@ import session from "express-session";
 import bcrypt from "bcrypt"; // Added bcrypt import
 import MemoryStore from "memorystore";
 import { AuthService } from "./services/auth";
+import nvmeRouter from "./routes/nvme";
 import { SystemService } from "./services/system";
 import { loginSchema, User } from "@shared/schema"; // Added User
 import { storage } from "./storage"; // Added storage import
@@ -38,6 +39,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
       sameSite: 'lax' // Better cookie handling for same-site requests
     }
   }));
+
+  // NVMe metrics route
+  app.use(nvmeRouter);
 
   // Auth middleware
   const requireAuth = (req: any, res: any, next: any) => {

--- a/server/routes/nvme.ts
+++ b/server/routes/nvme.ts
@@ -1,0 +1,36 @@
+import { Router } from 'express'
+import { exec } from 'child_process'
+
+const router = Router()
+
+router.get('/api/metrics/nvme', (_req, res) => {
+  exec('sudo smartctl -a /dev/nvme0', (err, stdout, stderr) => {
+    if (err || stderr) {
+      return res.status(500).json({ error: 'SMART data unavailable', details: stderr || err.message })
+    }
+
+    const lines = stdout.split('\n')
+    const metrics: {
+      temperature: string | null
+      power_on_hours: string | null
+      wear_leveling_count: string | null
+      media_errors: string | null
+    } = {
+      temperature: null,
+      power_on_hours: null,
+      wear_leveling_count: null,
+      media_errors: null,
+    }
+
+    for (const line of lines) {
+      if (line.includes('Temperature:')) metrics.temperature = line.split(':')[1].trim().split(' ')[0]
+      if (line.includes('Power On Hours')) metrics.power_on_hours = line.split(':')[1].trim()
+      if (line.includes('Wear Leveling Count')) metrics.wear_leveling_count = line.split(':')[1].trim()
+      if (line.includes('Media and Data Integrity Errors')) metrics.media_errors = line.split(':')[1].trim()
+    }
+
+    res.json(metrics)
+  })
+})
+
+export default router


### PR DESCRIPTION
## Summary
- add backend route `/api/metrics/nvme` to fetch SMART data via `smartctl`
- show NVMe SMART values in a new `NvmeHealthBox` widget
- mount `NvmeHealthBox` in the system overview dashboard

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6857547248b88322b7d94bc131504188