### PR TITLE
Add CPU frequency widget with backend route

### DIFF
--- a/client/src/components/system-overview.tsx
+++ b/client/src/components/system-overview.tsx
@@ -20,6 +20,7 @@ import {
 import { DiskIOGraph, NetworkBandwidthGraph } from "./resource-graphs";
 import ProcessList from "./process-list";
 import { NvmeHealthBox } from "./widgets/NvmeHealthBox";
+import { CpuFreqBox } from "./widgets/CpuFreqBox";
 
 interface OverviewProps {
   onOpenApps?: () => void;
@@ -168,6 +169,7 @@ export default function SystemOverview({ onOpenApps, onOpenLogs, onUpdateSystem,
         </Card>
 
         <NvmeHealthBox />
+        <CpuFreqBox />
       </div>
 
       {/* Resource Graphs */}

--- a/client/src/components/widgets/CpuFreqBox.tsx
+++ b/client/src/components/widgets/CpuFreqBox.tsx
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query'
+
+const fetchCpuFreq = async () => {
+  const res = await fetch('/api/metrics/cpu-freq')
+  if (!res.ok) throw new Error('Failed to fetch')
+  return res.json()
+}
+
+export function CpuFreqBox() {
+  const { data, error, isLoading } = useQuery({
+    queryKey: ['cpu-freq'],
+    queryFn: fetchCpuFreq,
+    refetchInterval: 5000,
+  })
+
+  return (
+    <div className="rounded-2xl border p-4 shadow bg-[#0f172a] text-white w-full max-w-sm">
+      <h3 className="text-lg font-semibold mb-2">CPU Frequency</h3>
+      {isLoading ? (
+        <p>Loading...</p>
+      ) : error || !data ? (
+        <p className="text-red-400">Unavailable</p>
+      ) : (
+        <ul className="space-y-1 text-sm">
+          {data.map((core: { core: string; freq: string }) => (
+            <li key={core.core}><strong>{core.core.toUpperCase()}:</strong> {core.freq}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,10 +2,12 @@ import "./env"; // Load environment variables first
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
+import cpuFreqRoute from "./routes/cpuFreq";
 
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
+app.use(cpuFreqRoute);
 
 app.use((req, res, next) => {
   const start = Date.now();

--- a/server/routes/cpuFreq.ts
+++ b/server/routes/cpuFreq.ts
@@ -1,0 +1,28 @@
+import { Router } from 'express'
+import { readdirSync, readFileSync } from 'fs'
+
+const router = Router()
+
+router.get('/api/metrics/cpu-freq', (_req, res) => {
+  try {
+    const cpus = readdirSync('/sys/devices/system/cpu')
+      .filter((name) => /^cpu[0-9]+$/.test(name))
+
+    const freqs = cpus.map((cpu) => {
+      const path = `/sys/devices/system/cpu/${cpu}/cpufreq/scaling_cur_freq`
+      try {
+        const raw = readFileSync(path, 'utf8').trim()
+        const ghz = (parseInt(raw) / 1_000_000).toFixed(2) + ' GHz'
+        return { core: cpu, freq: ghz }
+      } catch {
+        return { core: cpu, freq: 'Unavailable' }
+      }
+    })
+
+    res.json(freqs)
+  } catch (err) {
+    res.status(500).json({ error: 'Could not read CPU frequencies' })
+  }
+})
+
+export default router


### PR DESCRIPTION
## Summary
- add API route to read CPU frequencies per core
- expose route from Express server
- create CpuFreqBox widget in frontend
- display CPU frequency widget alongside NVMe status

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_685769e78ae483228ce8c6d4b8e89237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a CPU frequency widget to the system overview, displaying real-time frequency data for each CPU core.
  - Introduced a new API endpoint to provide up-to-date CPU frequency information.
- **Bug Fixes**
  - None.
- **Documentation**
  - None.
- **Refactor**
  - None.
- **Style**
  - None.
- **Tests**
  - None.
- **Chores**
  - None.
- **Revert**
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->