### PR TITLE
Add power supply status widget

### DIFF
--- a/client/src/components/system-overview.tsx
+++ b/client/src/components/system-overview.tsx
@@ -22,6 +22,7 @@ import ProcessList from "./process-list";
 import { NvmeHealthBox } from "./widgets/NvmeHealthBox";
 import { CpuFreqBox } from "./widgets/CpuFreqBox";
 import { ThermalZoneBox } from "./widgets/ThermalZoneBox";
+import { PowerStatusBox } from "./widgets/PowerStatusBox";
 
 interface OverviewProps {
   onOpenApps?: () => void;
@@ -172,6 +173,7 @@ export default function SystemOverview({ onOpenApps, onOpenLogs, onUpdateSystem,
         <NvmeHealthBox />
         <CpuFreqBox />
         <ThermalZoneBox />
+        <PowerStatusBox />
       </div>
 
       {/* Resource Graphs */}

--- a/client/src/components/widgets/PowerStatusBox.tsx
+++ b/client/src/components/widgets/PowerStatusBox.tsx
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query'
+
+const fetchPowerStatus = async () => {
+  const res = await fetch('/api/metrics/power-status')
+  if (!res.ok) throw new Error('Failed to fetch')
+  return res.json()
+}
+
+export function PowerStatusBox() {
+  const { data, error, isLoading } = useQuery({
+    queryKey: ['power-status'],
+    queryFn: fetchPowerStatus,
+    refetchInterval: 10000,
+  })
+
+  let status = '✅ Normal'
+  if (data?.undervoltageNow || data?.throttlingNow) {
+    status = '🔴 Throttling Now'
+  } else if (data?.undervoltageOccurred || data?.throttlingOccurred) {
+    status = '⚠️ Throttled Previously'
+  }
+
+  return (
+    <div className="rounded-2xl border p-4 shadow bg-[#0f172a] text-white w-full max-w-sm">
+      <h3 className="text-lg font-semibold mb-2">Power Status</h3>
+      {isLoading ? (
+        <p>Loading...</p>
+      ) : error || !data ? (
+        <p className="text-red-400">Unavailable</p>
+      ) : (
+        <div className="space-y-1 text-sm">
+          <p>{status}</p>
+          <p className="text-xs text-gray-400">Hex Code: 0x{data.hex}</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -4,12 +4,14 @@ import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 import cpuFreqRoute from "./routes/cpuFreq";
 import thermalZonesRoute from "./routes/thermalZones";
+import powerStatusRoute from "./routes/powerStatus";
 
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cpuFreqRoute);
 app.use(thermalZonesRoute);
+app.use(powerStatusRoute);
 
 app.use((req, res, next) => {
   const start = Date.now();

--- a/server/routes/powerStatus.ts
+++ b/server/routes/powerStatus.ts
@@ -1,0 +1,29 @@
+import { Router } from 'express'
+import { exec } from 'child_process'
+
+const router = Router()
+
+router.get('/api/metrics/power-status', (_req, res) => {
+  exec('vcgencmd get_throttled', (err, stdout, stderr) => {
+    if (err || stderr) {
+      return res.status(500).json({ error: 'Power check failed' })
+    }
+
+    const match = stdout.match(/throttled=0x([0-9a-fA-F]+)/)
+    if (!match) return res.status(500).json({ error: 'Unexpected output' })
+
+    const hex = match[1]
+    const bin = parseInt(hex, 16).toString(2).padStart(20, '0')
+
+    const flags = {
+      undervoltageNow: bin[19] === '1',
+      throttlingNow: bin[18] === '1',
+      undervoltageOccurred: bin[16] === '1',
+      throttlingOccurred: bin[17] === '1',
+    }
+
+    res.json({ hex, ...flags })
+  })
+})
+
+export default router


### PR DESCRIPTION
## Summary
- add `/api/metrics/power-status` endpoint on server
- show power status widget in dashboard

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685791607d2083229c148d0a68ede3b7