### PR TITLE
Add filesystem usage widget

### DIFF
--- a/client/src/components/system-overview.tsx
+++ b/client/src/components/system-overview.tsx
@@ -23,6 +23,7 @@ import { NvmeHealthBox } from "./widgets/NvmeHealthBox";
 import { CpuFreqBox } from "./widgets/CpuFreqBox";
 import { ThermalZoneBox } from "./widgets/ThermalZoneBox";
 import { PowerStatusBox } from "./widgets/PowerStatusBox";
+import { FilesystemUsageBox } from "./widgets/FilesystemUsageBox";
 
 interface OverviewProps {
   onOpenApps?: () => void;
@@ -174,6 +175,11 @@ export default function SystemOverview({ onOpenApps, onOpenLogs, onUpdateSystem,
         <CpuFreqBox />
         <ThermalZoneBox />
         <PowerStatusBox />
+      </div>
+
+      {/* Additional Metrics */}
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
+        <FilesystemUsageBox />
       </div>
 
       {/* Resource Graphs */}

--- a/client/src/components/widgets/FilesystemUsageBox.tsx
+++ b/client/src/components/widgets/FilesystemUsageBox.tsx
@@ -1,0 +1,49 @@
+import { useQuery } from '@tanstack/react-query'
+
+const fetchFsUsage = async () => {
+  const res = await fetch('/api/metrics/filesystems')
+  if (!res.ok) throw new Error('Failed to fetch')
+  return res.json()
+}
+
+export function FilesystemUsageBox() {
+  const { data, error, isLoading } = useQuery({
+    queryKey: ['filesystem-usage'],
+    queryFn: fetchFsUsage,
+    refetchInterval: 10000,
+  })
+
+  return (
+    <div className="rounded-2xl border p-4 shadow bg-[#0f172a] text-white w-full max-w-2xl">
+      <h3 className="text-lg font-semibold mb-2">Filesystem Usage</h3>
+      {isLoading ? (
+        <p>Loading...</p>
+      ) : error || !data ? (
+        <p className="text-red-400">Unavailable</p>
+      ) : (
+        <table className="text-sm w-full">
+          <thead>
+            <tr className="text-gray-400">
+              <th className="text-left">Mount</th>
+              <th className="text-left">Used</th>
+              <th className="text-left">Free</th>
+              <th className="text-left">Size</th>
+              <th className="text-left">%</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((fs: any, i: number) => (
+              <tr key={i}>
+                <td>{fs.mount}</td>
+                <td>{fs.used}</td>
+                <td>{fs.avail}</td>
+                <td>{fs.size}</td>
+                <td>{fs.pcent}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,6 +5,7 @@ import { setupVite, serveStatic, log } from "./vite";
 import cpuFreqRoute from "./routes/cpuFreq";
 import thermalZonesRoute from "./routes/thermalZones";
 import powerStatusRoute from "./routes/powerStatus";
+import filesystemRoute from "./routes/filesystem";
 
 const app = express();
 app.use(express.json());
@@ -12,6 +13,7 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cpuFreqRoute);
 app.use(thermalZonesRoute);
 app.use(powerStatusRoute);
+app.use(filesystemRoute);
 
 app.use((req, res, next) => {
   const start = Date.now();

--- a/server/routes/filesystem.ts
+++ b/server/routes/filesystem.ts
@@ -1,0 +1,24 @@
+import { Router } from 'express'
+import { exec } from 'child_process'
+
+const router = Router()
+
+router.get('/api/metrics/filesystems', (_req, res) => {
+  exec('df -h --output=source,size,used,avail,pcent,target', (err, stdout, stderr) => {
+    if (err || stderr) {
+      return res.status(500).json({ error: 'Failed to run df -h', details: stderr || err.message })
+    }
+
+    const lines = stdout.trim().split('\n').slice(1) // skip header
+    const entries = lines
+      .map(line => line.trim().split(/\s+/))
+      .filter(([src]) => !src.startsWith('tmpfs') && !src.startsWith('loop') && !src.includes('snap') && !src.includes('squashfs'))
+      .map(([source, size, used, avail, pcent, target]) => ({
+        source, size, used, avail, pcent, mount: target
+      }))
+
+    res.json(entries)
+  })
+})
+
+export default router


### PR DESCRIPTION
## Summary
- provide an API to read mounted filesystem info
- register the new filesystem route
- show filesystem usage in dashboard

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6857a0836894832286c012a1c02fd0f0