### PR TITLE
Fix filesystem row layout

### DIFF
--- a/client/src/components/filesystem-disk-row.tsx
+++ b/client/src/components/filesystem-disk-row.tsx
@@ -1,0 +1,15 @@
+import { FilesystemUsageBox } from '@/components/widgets/FilesystemUsageBox'
+import { MountInfoBox } from '@/components/widgets/MountInfoBox'
+
+export function FilesystemDiskRow() {
+  return (
+    <div className="flex flex-wrap gap-6 mt-6 w-full">
+      <div className="flex-1 min-w-[300px] max-w-[48%]">
+        <FilesystemUsageBox />
+      </div>
+      <div className="flex-1 min-w-[300px] max-w-[48%]">
+        <MountInfoBox />
+      </div>
+    </div>
+  )
+}

--- a/client/src/components/system-overview.tsx
+++ b/client/src/components/system-overview.tsx
@@ -25,6 +25,7 @@ import { ThermalZoneBox } from "./widgets/ThermalZoneBox";
 import { PowerStatusBox } from "./widgets/PowerStatusBox";
 import { FilesystemUsageBox } from "./widgets/FilesystemUsageBox";
 import { MountInfoBox } from "./widgets/MountInfoBox";
+import { FilesystemDiskRow } from "./filesystem-disk-row";
 
 interface OverviewProps {
   onOpenApps?: () => void;
@@ -179,10 +180,7 @@ export default function SystemOverview({ onOpenApps, onOpenLogs, onUpdateSystem,
       </div>
 
       {/* Additional Metrics */}
-      <div className="flex flex-wrap gap-6 mt-6">
-        <FilesystemUsageBox />
-        <MountInfoBox />
-      </div>
+      <FilesystemDiskRow />
 
       {/* Resource Graphs */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">


### PR DESCRIPTION
## Summary
- add `FilesystemDiskRow` layout component
- use it in `SystemOverview` to align filesystem and mount widgets

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6857db2770f883229aff4e0fb90229ca

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new unified row layout for displaying filesystem usage and mount information, providing a more organized and responsive presentation of these metrics.

- **Refactor**
  - Consolidated the display of filesystem-related metrics into a single component for improved clarity and layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->