### PR TITLE
Add memory & process insights row

### DIFF
--- a/client/src/components/memory-process-row.tsx
+++ b/client/src/components/memory-process-row.tsx
@@ -1,0 +1,19 @@
+import { RamStatsBox } from '@/components/widgets/RamStatsBox'
+import { SwapUsageBox } from '@/components/widgets/SwapUsageBox'
+import { TopProcessesBox } from '@/components/widgets/TopProcessesBox'
+
+export function MemoryProcessRow() {
+  return (
+    <div className="flex flex-wrap gap-6 mt-6 w-full">
+      <div className="flex-1 min-w-[300px] max-w-[30%]">
+        <RamStatsBox />
+      </div>
+      <div className="flex-1 min-w-[300px] max-w-[30%]">
+        <SwapUsageBox />
+      </div>
+      <div className="flex-1 min-w-[300px] max-w-[30%]">
+        <TopProcessesBox />
+      </div>
+    </div>
+  )
+}

--- a/client/src/components/system-overview.tsx
+++ b/client/src/components/system-overview.tsx
@@ -26,6 +26,7 @@ import { PowerStatusBox } from "./widgets/PowerStatusBox";
 import { FilesystemUsageBox } from "./widgets/FilesystemUsageBox";
 import { MountInfoBox } from "./widgets/MountInfoBox";
 import { FilesystemDiskRow } from "./filesystem-disk-row";
+import { MemoryProcessRow } from "./memory-process-row";
 
 interface OverviewProps {
   onOpenApps?: () => void;
@@ -181,6 +182,7 @@ export default function SystemOverview({ onOpenApps, onOpenLogs, onUpdateSystem,
 
       {/* Additional Metrics */}
       <FilesystemDiskRow />
+      <MemoryProcessRow />
 
       {/* Resource Graphs */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/client/src/components/widgets/RamStatsBox.tsx
+++ b/client/src/components/widgets/RamStatsBox.tsx
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query'
+
+const fetchRamStats = async () => {
+  const res = await fetch('/api/metrics/ram')
+  if (!res.ok) throw new Error('Failed to fetch')
+  return res.json()
+}
+
+export function RamStatsBox() {
+  const { data, error, isLoading } = useQuery({
+    queryKey: ['ram-stats'],
+    queryFn: fetchRamStats,
+    refetchInterval: 10000,
+  })
+
+  return (
+    <div className="rounded-2xl border p-4 shadow bg-[#0f172a] text-white w-full">
+      <h3 className="text-lg font-semibold mb-2">RAM Stats</h3>
+      {isLoading ? (
+        <p>Loading...</p>
+      ) : error || !data ? (
+        <p className="text-red-400">Unavailable</p>
+      ) : (
+        <div className="text-sm space-y-1">
+          <p>Total: {data.total}MB</p>
+          <p>Used: {data.used}MB</p>
+          <p>Free: {data.free}MB</p>
+          <p>Usage: {data.usage}%{data.usage > 90 ? ' ⚠️' : ''}</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/client/src/components/widgets/SwapUsageBox.tsx
+++ b/client/src/components/widgets/SwapUsageBox.tsx
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query'
+
+const fetchSwap = async () => {
+  const res = await fetch('/api/metrics/swap')
+  if (!res.ok) throw new Error('Failed to fetch')
+  return res.json()
+}
+
+export function SwapUsageBox() {
+  const { data, error, isLoading } = useQuery({
+    queryKey: ['swap-usage'],
+    queryFn: fetchSwap,
+    refetchInterval: 10000,
+  })
+
+  return (
+    <div className="rounded-2xl border p-4 shadow bg-[#0f172a] text-white w-full">
+      <h3 className="text-lg font-semibold mb-2">Swap Usage</h3>
+      {isLoading ? (
+        <p>Loading...</p>
+      ) : error || !data ? (
+        <p className="text-red-400">Unavailable</p>
+      ) : (
+        <div className="text-sm space-y-1">
+          <p>Total: {data.total}MB</p>
+          <p>Used: <span className={data.used > 0 ? 'text-yellow-400' : ''}>{data.used}MB</span></p>
+          <p>Free: {data.free}MB</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/client/src/components/widgets/TopProcessesBox.tsx
+++ b/client/src/components/widgets/TopProcessesBox.tsx
@@ -1,0 +1,47 @@
+import { useQuery } from '@tanstack/react-query'
+
+const fetchTopProcesses = async () => {
+  const res = await fetch('/api/metrics/top-processes')
+  if (!res.ok) throw new Error('Failed to fetch')
+  return res.json()
+}
+
+export function TopProcessesBox() {
+  const { data, error, isLoading } = useQuery({
+    queryKey: ['top-processes'],
+    queryFn: fetchTopProcesses,
+    refetchInterval: 10000,
+  })
+
+  return (
+    <div className="rounded-2xl border p-4 shadow bg-[#0f172a] text-white w-full overflow-x-auto">
+      <h3 className="text-lg font-semibold mb-2">Top Processes</h3>
+      {isLoading ? (
+        <p>Loading...</p>
+      ) : error || !data ? (
+        <p className="text-red-400">Unavailable</p>
+      ) : (
+        <table className="text-sm w-full">
+          <thead className="text-gray-400">
+            <tr>
+              <th className="text-left">PID</th>
+              <th className="text-left">Name</th>
+              <th className="text-right">CPU%</th>
+              <th className="text-right">MEM%</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((p: any) => (
+              <tr key={p.pid}>
+                <td>{p.pid}</td>
+                <td>{p.name}</td>
+                <td className="text-right">{p.cpu.toFixed(1)}</td>
+                <td className="text-right">{p.mem.toFixed(1)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,6 +7,8 @@ import thermalZonesRoute from "./routes/thermalZones";
 import powerStatusRoute from "./routes/powerStatus";
 import filesystemRoute from "./routes/filesystem";
 import mountsRoute from "./routes/mounts";
+import memoryRoute from "./routes/memory";
+import topProcessesRoute from "./routes/topProcesses";
 
 const app = express();
 app.use(express.json());
@@ -16,6 +18,8 @@ app.use(thermalZonesRoute);
 app.use(powerStatusRoute);
 app.use(filesystemRoute);
 app.use(mountsRoute);
+app.use(memoryRoute);
+app.use(topProcessesRoute);
 
 app.use((req, res, next) => {
   const start = Date.now();

--- a/server/routes/memory.ts
+++ b/server/routes/memory.ts
@@ -1,0 +1,33 @@
+import { Router } from 'express'
+import { exec } from 'child_process'
+
+const router = Router()
+
+router.get('/api/metrics/ram', (_req, res) => {
+  exec("free -m | awk '/Mem:/ {print $2, $3, $4}'", (err, stdout, stderr) => {
+    if (err || stderr) {
+      return res.status(500).json({ error: 'Failed to read memory', details: stderr || err.message })
+    }
+    const [totalStr, usedStr, freeStr] = stdout.trim().split(/\s+/)
+    const total = parseInt(totalStr)
+    const used = parseInt(usedStr)
+    const free = parseInt(freeStr)
+    const usage = total > 0 ? Math.round((used / total) * 100) : 0
+    res.json({ total, used, free, usage })
+  })
+})
+
+router.get('/api/metrics/swap', (_req, res) => {
+  exec("free -m | awk '/Swap:/ {print $2, $3, $4}'", (err, stdout, stderr) => {
+    if (err || stderr) {
+      return res.status(500).json({ error: 'Failed to read swap', details: stderr || err.message })
+    }
+    const [totalStr, usedStr, freeStr] = stdout.trim().split(/\s+/)
+    const total = parseInt(totalStr)
+    const used = parseInt(usedStr)
+    const free = parseInt(freeStr)
+    res.json({ total, used, free })
+  })
+})
+
+export default router

--- a/server/routes/topProcesses.ts
+++ b/server/routes/topProcesses.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express'
+import { exec } from 'child_process'
+
+const router = Router()
+
+router.get('/api/metrics/top-processes', (_req, res) => {
+  exec('ps -eo pid,comm,%cpu,%mem --sort=-%mem | head -n 6', (err, stdout, stderr) => {
+    if (err || stderr) {
+      return res.status(500).json({ error: 'Failed to list processes', details: stderr || err.message })
+    }
+    const lines = stdout.trim().split('\n').slice(1)
+    const processes = lines.map(line => {
+      const [pid, name, cpu, mem] = line.trim().split(/\s+/, 4)
+      return {
+        pid: parseInt(pid),
+        name,
+        cpu: parseFloat(cpu),
+        mem: parseFloat(mem)
+      }
+    })
+    res.json(processes)
+  })
+})
+
+export default router


### PR DESCRIPTION
## Summary
- provide RAM/swap/process stats endpoints on server
- create widgets for RAM, swap, and top processes
- include MemoryProcessRow below the filesystem row in system overview
- register new routes in the server

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6857e163e754832299583d43c12989d3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new "Memory & Processes" section to the system overview, displaying real-time RAM stats, swap usage, and top system processes.
  - Users can now view total, used, and free RAM and swap memory, with warnings for high usage.
  - The top 5 processes by memory usage are now shown, including details like PID, CPU, and memory percentage.

- **Bug Fixes**
  - None.

- **Documentation**
  - None.

- **Refactor**
  - None.

- **Style**
  - None.

- **Tests**
  - None.

- **Chores**
  - None.

- **Revert**
  - None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->