### PR TITLE
Fix power status error handling

### DIFF
--- a/client/src/components/widgets/PowerStatusBox.tsx
+++ b/client/src/components/widgets/PowerStatusBox.tsx
@@ -12,13 +12,7 @@ export function PowerStatusBox() {
     queryFn: fetchPowerStatus,
     refetchInterval: 10000,
   })
-
-  let status = '✅ Normal'
-  if (data?.undervoltageNow || data?.throttlingNow) {
-    status = '🔴 Throttling Now'
-  } else if (data?.undervoltageOccurred || data?.throttlingOccurred) {
-    status = '⚠️ Throttled Previously'
-  }
+  const statusLabel = data?.status ?? 'Unavailable'
 
   return (
     <div className="rounded-2xl border p-4 shadow bg-[#0f172a] text-white w-full max-w-sm">
@@ -29,8 +23,10 @@ export function PowerStatusBox() {
         <p className="text-red-400">Unavailable</p>
       ) : (
         <div className="space-y-1 text-sm">
-          <p>{status}</p>
-          <p className="text-xs text-gray-400">Hex Code: 0x{data.hex}</p>
+          <p>{statusLabel}</p>
+          <p className="text-xs text-gray-400">
+            Voltage: {data.voltage !== null && data.voltage !== undefined ? data.voltage.toFixed(2) + 'V' : 'N/A'}
+          </p>
         </div>
       )}
     </div>

--- a/client/src/components/widgets/TopProcessesBox.tsx
+++ b/client/src/components/widgets/TopProcessesBox.tsx
@@ -35,8 +35,8 @@ export function TopProcessesBox() {
               <tr key={p.pid}>
                 <td>{p.pid}</td>
                 <td>{p.name}</td>
-                <td className="text-right">{p.cpu.toFixed(1)}</td>
-                <td className="text-right">{p.mem.toFixed(1)}</td>
+                <td className="text-right">{p.cpu !== null && p.cpu !== undefined ? p.cpu.toFixed(1) : 'N/A'}</td>
+                <td className="text-right">{p.mem !== null && p.mem !== undefined ? p.mem.toFixed(1) : 'N/A'}</td>
               </tr>
             ))}
           </tbody>

--- a/server/routes/powerStatus.ts
+++ b/server/routes/powerStatus.ts
@@ -9,41 +9,44 @@ router.get('/api/metrics/power-status', (_req, res) => {
       ...process.env,
       PATH: `${process.env.PATH ?? ''}:/usr/bin`,
     },
-  }, (err, stdout, stderr) => {
-    const output = stdout.trim()
-    const errorOutput = stderr?.trim()
+  }, (throttleErr, throttleOut) => {
+    const output = throttleOut.trim()
 
-    if (err || errorOutput) {
-      console.error('vcgencmd error:', err?.message || errorOutput)
-      return res.status(500).json({
-        error: 'Command failed',
-        details: errorOutput || err.message,
+    let status = 'Unavailable'
+    if (!throttleErr) {
+      const match = output.match(/throttled=0x([0-9a-fA-F]+)/)
+      if (match) {
+        const binary = parseInt(match[1], 16).toString(2).padStart(20, '0')
+        const undervoltageNow = binary[19] === '1'
+        const throttlingNow = binary[18] === '1'
+        const undervoltageOccurred = binary[16] === '1'
+        const throttlingOccurred = binary[17] === '1'
+
+        if (undervoltageNow || throttlingNow) status = 'Throttling'
+        else if (undervoltageOccurred || throttlingOccurred) status = 'Throttled'
+        else status = 'Normal'
+      }
+    }
+
+    exec('/usr/bin/vcgencmd measure_volts', {
+      env: {
+        ...process.env,
+        PATH: `${process.env.PATH ?? ''}:/usr/bin`,
+      },
+    }, (voltErr, voltOut) => {
+      let voltage: number | null = null
+      if (!voltErr) {
+        const vmatch = voltOut.trim().match(/volt=([0-9.]+)V/)
+        if (vmatch) {
+          voltage = parseFloat(vmatch[1])
+        }
+      }
+
+      res.json({
+        voltage,
+        current: null,
+        status,
       })
-    }
-
-    const match = output.match(/throttled=0x([0-9a-fA-F]+)/)
-    if (!match) {
-      return res.status(500).json({
-        error: 'Unexpected output format',
-        rawOutput: output,
-      })
-    }
-
-    const hex = match[1]
-    const binary = parseInt(hex, 16).toString(2).padStart(20, '0')
-
-    const flags = {
-      undervoltageNow: binary[19] === '1',
-      throttlingNow: binary[18] === '1',
-      throttlingOccurred: binary[17] === '1',
-      undervoltageOccurred: binary[16] === '1',
-    }
-
-    res.json({
-      rawOutput: output,
-      parsedHex: hex,
-      binary,
-      flags,
     })
   })
 })


### PR DESCRIPTION
## Summary
- handle missing `vcgencmd` gracefully
- adapt frontend power status widget to new response
- guard `toFixed()` usage in TopProcesses box

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6857fd2506308322bfaec04e2507bff6