### PR TITLE
Add network widgets and API endpoints

### DIFF
--- a/client/src/components/network-row.tsx
+++ b/client/src/components/network-row.tsx
@@ -1,0 +1,13 @@
+import { IpConfigWidget } from '@/components/widgets/network/IpConfigWidget'
+import { ListeningPortsWidget } from '@/components/widgets/network/ListeningPortsWidget'
+import { FirewallStatusWidget } from '@/components/widgets/network/FirewallStatusWidget'
+
+export function NetworkRow() {
+  return (
+    <div className="grid grid-cols-3 gap-4 mt-6 w-full">
+      <IpConfigWidget />
+      <ListeningPortsWidget />
+      <FirewallStatusWidget />
+    </div>
+  )
+}

--- a/client/src/components/system-overview.tsx
+++ b/client/src/components/system-overview.tsx
@@ -27,6 +27,7 @@ import { FilesystemUsageBox } from "./widgets/FilesystemUsageBox";
 import { MountInfoBox } from "./widgets/MountInfoBox";
 import { FilesystemDiskRow } from "./filesystem-disk-row";
 import { MemoryProcessRow } from "./memory-process-row";
+import { NetworkRow } from "./network-row";
 
 interface OverviewProps {
   onOpenApps?: () => void;
@@ -189,6 +190,8 @@ export default function SystemOverview({ onOpenApps, onOpenLogs, onUpdateSystem,
         <DiskIOGraph />
         <NetworkBandwidthGraph />
       </div>
+
+      <NetworkRow />
 
       {/* System Information & Processes */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/client/src/components/widgets/network/FirewallStatusWidget.tsx
+++ b/client/src/components/widgets/network/FirewallStatusWidget.tsx
@@ -1,0 +1,44 @@
+import { useQuery } from '@tanstack/react-query'
+
+const fetchFirewallStatus = async () => {
+  const res = await fetch('/api/metrics/firewall-status')
+  if (!res.ok) throw new Error('Failed to fetch')
+  return res.json()
+}
+
+export function FirewallStatusWidget() {
+  const { data, error, isLoading } = useQuery({
+    queryKey: ['firewall-status'],
+    queryFn: fetchFirewallStatus,
+    refetchInterval: 15000,
+  })
+
+  const statusColor = data?.enabled ? 'text-green-400' : 'text-red-400'
+
+  return (
+    <div className="rounded-2xl border p-4 shadow bg-[#0f172a] text-white w-full">
+      <h3 className="text-lg font-semibold mb-2">Firewall Status</h3>
+      {isLoading ? (
+        <p>Loading...</p>
+      ) : error || !data ? (
+        <p className="text-red-400">Unavailable</p>
+      ) : (
+        <div className="text-sm space-y-1">
+          <p>Status: <span className={statusColor}>{data.enabled ? 'Active' : 'Disabled'}</span></p>
+          <p>Incoming: {data.defaultIncoming}</p>
+          <p>Outgoing: {data.defaultOutgoing}</p>
+          <div>
+            <p>Rules:</p>
+            <ul className="ml-4 max-h-24 overflow-y-auto list-disc list-inside">
+              {data.rules.map((r: any, idx: number) => (
+                <li key={idx} className="font-mono">
+                  {r.port}/{r.protocol} {r.action}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/client/src/components/widgets/network/IpConfigWidget.tsx
+++ b/client/src/components/widgets/network/IpConfigWidget.tsx
@@ -1,0 +1,39 @@
+import { useQuery } from '@tanstack/react-query'
+
+const fetchIpConfig = async () => {
+  const res = await fetch('/api/metrics/ip-config')
+  if (!res.ok) throw new Error('Failed to fetch')
+  return res.json()
+}
+
+export function IpConfigWidget() {
+  const { data, error, isLoading } = useQuery({
+    queryKey: ['ip-config'],
+    queryFn: fetchIpConfig,
+    refetchInterval: 15000,
+  })
+
+  return (
+    <div className="rounded-2xl border p-4 shadow bg-[#0f172a] text-white w-full">
+      <h3 className="text-lg font-semibold mb-2">IP Configuration</h3>
+      {isLoading ? (
+        <p>Loading...</p>
+      ) : error || !data ? (
+        <p className="text-red-400">Unavailable</p>
+      ) : (
+        <div className="text-sm space-y-1">
+          <p>IP: <span className="font-mono">{data.ip}</span></p>
+          <p>Gateway: <span className="font-mono">{data.gateway}</span></p>
+          <div>
+            <p>DNS:</p>
+            <ul className="ml-4 max-h-24 overflow-y-auto list-disc list-inside">
+              {data.dns.map((d: string) => (
+                <li key={d} className="font-mono">{d}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/client/src/components/widgets/network/ListeningPortsWidget.tsx
+++ b/client/src/components/widgets/network/ListeningPortsWidget.tsx
@@ -1,0 +1,48 @@
+import { useQuery } from '@tanstack/react-query'
+
+const fetchListeningPorts = async () => {
+  const res = await fetch('/api/metrics/listening-ports')
+  if (!res.ok) throw new Error('Failed to fetch')
+  return res.json()
+}
+
+export function ListeningPortsWidget() {
+  const { data, error, isLoading } = useQuery({
+    queryKey: ['listening-ports'],
+    queryFn: fetchListeningPorts,
+    refetchInterval: 15000,
+  })
+
+  return (
+    <div className="rounded-2xl border p-4 shadow bg-[#0f172a] text-white w-full">
+      <h3 className="text-lg font-semibold mb-2">Listening Ports</h3>
+      {isLoading ? (
+        <p>Loading...</p>
+      ) : error || !data ? (
+        <p className="text-red-400">Unavailable</p>
+      ) : (
+        <div className="max-h-40 overflow-y-auto text-sm">
+          <table className="w-full">
+            <thead className="text-gray-400 text-xs">
+              <tr>
+                <th className="text-left">Port</th>
+                <th className="text-left">Protocol</th>
+                <th className="text-left">Service</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.map((p: any) => (
+                <tr key={`${p.protocol}-${p.port}`}
+                    className="odd:bg-pi-darker">
+                  <td className="font-mono">{p.port}</td>
+                  <td>{p.protocol}</td>
+                  <td>{p.service || '-'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,7 @@ import filesystemRoute from "./routes/filesystem";
 import mountsRoute from "./routes/mounts";
 import memoryRoute from "./routes/memory";
 import topProcessesRoute from "./routes/topProcesses";
+import networkRoute from "./routes/network";
 
 const app = express();
 app.use(express.json());
@@ -20,6 +21,7 @@ app.use(filesystemRoute);
 app.use(mountsRoute);
 app.use(memoryRoute);
 app.use(topProcessesRoute);
+app.use(networkRoute);
 
 app.use((req, res, next) => {
   const start = Date.now();

--- a/server/routes/network.ts
+++ b/server/routes/network.ts
@@ -1,0 +1,76 @@
+import { Router } from 'express'
+import { exec } from 'child_process'
+import { promisify } from 'util'
+
+const router = Router()
+const execAsync = promisify(exec)
+
+router.get('/api/metrics/ip-config', async (_req, res) => {
+  try {
+    const { stdout: ipOut } = await execAsync("ip -4 addr show | grep -oP '(?<=inet\\s)\\d+(?:\\.\\d+){3}' | head -n 1")
+    const ip = ipOut.trim()
+    const { stdout: gwOut } = await execAsync("ip route | awk '/default/ {print $3}'")
+    const gateway = gwOut.trim()
+    let dnsOut = ''
+    try {
+      const { stdout } = await execAsync("resolvectl dns 2>/dev/null | awk 'NR>1 {print $2}'")
+      dnsOut = stdout
+    } catch {
+      const { stdout } = await execAsync("grep nameserver /etc/resolv.conf | awk '{print $2}'")
+      dnsOut = stdout
+    }
+    const dns = dnsOut.trim().split(/\s+/).filter(Boolean)
+    res.json({ ip, gateway, dns })
+  } catch (err: any) {
+    res.status(500).json({ error: 'Failed to fetch IP config', details: err.message })
+  }
+})
+
+router.get('/api/metrics/listening-ports', async (_req, res) => {
+  try {
+    const { stdout } = await execAsync("ss -tulnp")
+    const lines = stdout.trim().split('\n').slice(1)
+    const ports = lines.map(line => {
+      const portMatch = line.match(/:(\d+)/)
+      const protoMatch = line.match(/^(tcp|udp)/)
+      const serviceMatch = line.match(/users:\(\\(\"([^\",]+)/)
+      return portMatch && protoMatch ? {
+        port: parseInt(portMatch[1], 10),
+        protocol: protoMatch[1],
+        service: serviceMatch ? serviceMatch[2] : ''
+      } : null
+    }).filter(Boolean)
+    res.json(ports)
+  } catch (err: any) {
+    res.status(500).json({ error: 'Failed to fetch listening ports', details: err.message })
+  }
+})
+
+router.get('/api/metrics/firewall-status', async (_req, res) => {
+  try {
+    const { stdout } = await execAsync('ufw status verbose')
+    const enabled = stdout.includes('Status: active')
+    let defaultIncoming = ''
+    let defaultOutgoing = ''
+    const defaultMatch = stdout.match(/Default: ([^\n]+)/)
+    if (defaultMatch) {
+      const parts = defaultMatch[1].split(',')
+      for (const p of parts) {
+        if (p.includes('incoming')) defaultIncoming = p.trim().split(' ')[0]
+        if (p.includes('outgoing')) defaultOutgoing = p.trim().split(' ')[0]
+      }
+    }
+    const rules: { port: number; protocol: string; action: string }[] = []
+    stdout.split('\n').forEach(line => {
+      const m = line.match(/(\d+)(?:\/(tcp|udp))?\s+(ALLOW|DENY)/)
+      if (m) {
+        rules.push({ port: parseInt(m[1], 10), protocol: m[2] || 'tcp', action: m[3].toLowerCase() })
+      }
+    })
+    res.json({ enabled, defaultIncoming, defaultOutgoing, rules })
+  } catch (err: any) {
+    res.status(500).json({ error: 'Failed to fetch firewall status', details: err.message })
+  }
+})
+
+export default router


### PR DESCRIPTION
## Summary
- add API routes for IP config, listening ports and firewall status
- register the new routes
- create widgets for firewall status, IP configuration and listening ports
- add NetworkRow component and integrate into SystemOverview

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node', no internet)*

------
https://chatgpt.com/codex/tasks/task_e_685801e45b1883229cf16bf017d9194b