### PR TITLE
Fix network regex and metrics insert

### DIFF
--- a/server/routes/network.ts
+++ b/server/routes/network.ts
@@ -33,11 +33,11 @@ router.get('/api/metrics/listening-ports', async (_req, res) => {
     const ports = lines.map(line => {
       const portMatch = line.match(/:(\d+)/)
       const protoMatch = line.match(/^(tcp|udp)/)
-      const serviceMatch = line.match(/users:\(\\(\"([^\",]+)/)
+      const serviceMatch = line.match(/users:\(\("([^"]+)/)
       return portMatch && protoMatch ? {
         port: parseInt(portMatch[1], 10),
         protocol: protoMatch[1],
-        service: serviceMatch ? serviceMatch[2] : ''
+        service: serviceMatch ? serviceMatch[1] : ''
       } : null
     }).filter(Boolean)
     res.json(ports)

--- a/server/services/system.ts
+++ b/server/services/system.ts
@@ -235,16 +235,16 @@ private static async getNetworkBandwidth(): Promise<NetworkBandwidth> {
 
   private static async logHistoricalData(data: SystemInfo): Promise<void> {
     try {
-      const metricRecord: InsertHistoricalMetric = {
-        timestamp: new Date(), // Drizzle handles defaultNow, but explicit is fine
-        cpuUsage: Math.round(data.cpu),
-        memoryUsage: Math.round(data.memory.percentage),
-        temperature: Math.round(data.temperature),
-        diskReadSpeed: Math.round(data.diskIO?.readSpeed ?? 0),
-        diskWriteSpeed: Math.round(data.diskIO?.writeSpeed ?? 0),
-        networkRx: Math.round(data.networkBandwidth?.rx ?? 0),
-        networkTx: Math.round(data.networkBandwidth?.tx ?? 0),
-      };
+        const metricRecord: InsertHistoricalMetric = {
+          timestamp: new Date(), // Drizzle handles defaultNow, but explicit is fine
+          cpuUsage: Math.round(data.cpu ?? 0),
+          memoryUsage: Math.round(data.memory?.percentage ?? 0),
+          temperature: Math.round(data.temperature ?? 0),
+          diskReadSpeed: Math.round(data.diskIO?.readSpeed ?? 0),
+          diskWriteSpeed: Math.round(data.diskIO?.writeSpeed ?? 0),
+          networkRx: Math.round(data.networkBandwidth?.rx ?? 0),
+          networkTx: Math.round(data.networkBandwidth?.tx ?? 0),
+        };
       await db.insert(historicalMetrics).values(metricRecord);
 
       // Prune old data (older than 24 hours)


### PR DESCRIPTION
## Summary
- fix listening ports regex to properly capture service name
- sanitize historical metric values before database insert to prevent invalid DB arguments

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68580ac04b108322a72652f544f8a181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected extraction of service names from network information to ensure accurate display.
	- Improved handling of missing or undefined system metrics, defaulting values to zero for more reliable historical data logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->