### PR TITLE
Fix SystemInfo definition

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -130,7 +130,10 @@ export type SystemInfoExtended = {
   processes?: ProcessInfo[];
 };
 
-export type SystemInfo = SystemInfoExtended;
+export interface SystemInfo extends Omit<SystemInfoExtended, 'diskIO' | 'networkBandwidth'> {
+  diskIO: DiskIO;
+  networkBandwidth: NetworkBandwidth;
+}
 
 export interface ActiveAlert {
   id: string;


### PR DESCRIPTION
## Summary
- expose diskIO and networkBandwidth values from `SystemService`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68588fb12d608322960e7bfcaf81abb7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated system information structure to ensure disk I/O and network bandwidth details are always included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->