### PR TITLE
Fix mount widget height

### DIFF
--- a/client/src/components/widgets/MountInfoBox.tsx
+++ b/client/src/components/widgets/MountInfoBox.tsx
@@ -21,7 +21,7 @@ export function MountInfoBox() {
       ) : error || !data ? (
         <p className="text-red-400">Unavailable</p>
       ) : (
-        <div className="overflow-y-auto max-h-[300px]">
+        <div className="overflow-y-auto max-h-[160px] custom-scrollbar">
           <table className="text-sm w-full table-fixed">
             <thead className="text-gray-400 sticky top-0 bg-[#0f172a] z-10">
               <tr>


### PR DESCRIPTION
## Summary
- keep MountInfo widget compact by limiting height and adding scrollbars

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68589610a3e083228af7580f18052bbe