### PR TITLE
Add boot info widgets and API

### DIFF
--- a/client/src/components/boot-info-row.tsx
+++ b/client/src/components/boot-info-row.tsx
@@ -1,0 +1,19 @@
+import { BootDeviceBox } from '@/components/widgets/BootDeviceBox'
+import { UnderVoltageBox } from '@/components/widgets/UnderVoltageBox'
+import { NvmeSmartBox } from '@/components/widgets/NvmeSmartBox'
+
+export function BootInfoRow() {
+  return (
+    <div className="flex flex-wrap gap-6 mt-6 w-full">
+      <div className="flex-1 min-w-[300px] max-w-[32%]">
+        <BootDeviceBox />
+      </div>
+      <div className="flex-1 min-w-[300px] max-w-[32%]">
+        <UnderVoltageBox />
+      </div>
+      <div className="flex-1 min-w-[300px] max-w-[32%]">
+        <NvmeSmartBox />
+      </div>
+    </div>
+  )
+}

--- a/client/src/components/system-overview.tsx
+++ b/client/src/components/system-overview.tsx
@@ -28,6 +28,7 @@ import { MountInfoBox } from "./widgets/MountInfoBox";
 import { FilesystemDiskRow } from "./filesystem-disk-row";
 import { MemoryProcessRow } from "./memory-process-row";
 import { NetworkRow } from "./network-row";
+import { BootInfoRow } from "./boot-info-row";
 
 interface OverviewProps {
   onOpenApps?: () => void;
@@ -180,6 +181,8 @@ export default function SystemOverview({ onOpenApps, onOpenLogs, onUpdateSystem,
         <ThermalZoneBox />
         <PowerStatusBox />
       </div>
+
+      <BootInfoRow />
 
       {/* Additional Metrics */}
       <FilesystemDiskRow />

--- a/client/src/components/widgets/BootDeviceBox.tsx
+++ b/client/src/components/widgets/BootDeviceBox.tsx
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+const fetchBootInfo = async () => {
+  const res = await fetch('/api/system/boot-info')
+  if (!res.ok) throw new Error('Failed to fetch')
+  return res.json()
+}
+
+export function BootDeviceBox() {
+  const { data, error, isLoading, refetch } = useQuery({
+    queryKey: ['boot-info'],
+    queryFn: fetchBootInfo,
+    refetchInterval: 60000,
+  })
+
+  return (
+    <Card className="bg-pi-card border-pi-border h-full">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-lg">Boot Source</CardTitle>
+      </CardHeader>
+      <CardContent className="pt-0 text-sm">
+        {isLoading ? (
+          <p>Loading...</p>
+        ) : error || !data ? (
+          <p className="text-red-400">Unavailable</p>
+        ) : (
+          <p className="font-mono">
+            {data.bootDevice} → {data.rootDevice}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/client/src/components/widgets/NvmeSmartBox.tsx
+++ b/client/src/components/widgets/NvmeSmartBox.tsx
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+const fetchBootInfo = async () => {
+  const res = await fetch('/api/system/boot-info')
+  if (!res.ok) throw new Error('Failed to fetch')
+  return res.json()
+}
+
+export function NvmeSmartBox() {
+  const { data, error, isLoading } = useQuery({
+    queryKey: ['boot-info'],
+    queryFn: fetchBootInfo,
+    refetchInterval: 60000,
+  })
+
+  return (
+    <Card className="bg-pi-card border-pi-border h-full">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-lg">NVMe Health</CardTitle>
+      </CardHeader>
+      <CardContent className="pt-0 text-sm">
+        {isLoading ? (
+          <p>Loading...</p>
+        ) : error || !data ? (
+          <p className="text-red-400">Unavailable</p>
+        ) : (
+          <ul className="space-y-1">
+            <li>Temp: {data.nvme.temp}</li>
+            <li>Used: {data.nvme.percentUsed}</li>
+            <li>Power Cycles: {data.nvme.powerCycles}</li>
+            <li>Media Errors: {data.nvme.mediaErrors}</li>
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/client/src/components/widgets/UnderVoltageBox.tsx
+++ b/client/src/components/widgets/UnderVoltageBox.tsx
@@ -1,0 +1,40 @@
+import { useQuery } from '@tanstack/react-query'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+const fetchBootInfo = async () => {
+  const res = await fetch('/api/system/boot-info')
+  if (!res.ok) throw new Error('Failed to fetch')
+  return res.json()
+}
+
+export function UnderVoltageBox() {
+  const { data, error, isLoading } = useQuery({
+    queryKey: ['boot-info'],
+    queryFn: fetchBootInfo,
+    refetchInterval: 60000,
+  })
+
+  const isWarning = data?.undervoltage
+
+  return (
+    <Card className="bg-pi-card border-pi-border h-full">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-lg">Power Supply</CardTitle>
+      </CardHeader>
+      <CardContent className="pt-0 text-sm">
+        {isLoading ? (
+          <p>Loading...</p>
+        ) : error || !data ? (
+          <p className="text-red-400">Unavailable</p>
+        ) : (
+          <div>
+            <p className={isWarning ? 'text-red-400' : 'text-green-400'}>
+              {isWarning ? 'Undervoltage Detected' : 'Normal'}
+            </p>
+            <p className="text-xs text-gray-400">{data.throttleRaw}</p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,6 +11,7 @@ import memoryRoute from "./routes/memory";
 import topProcessesRoute from "./routes/topProcesses";
 import networkRoute from "./routes/network";
 import firewallRoute from "./routes/firewall";
+import bootInfoRoute from "./routes/bootInfo";
 
 const app = express();
 app.use(express.json());
@@ -24,6 +25,7 @@ app.use(memoryRoute);
 app.use(topProcessesRoute);
 app.use(networkRoute);
 app.use(firewallRoute);
+app.use(bootInfoRoute);
 
 app.use((req, res, next) => {
   const start = Date.now();

--- a/server/routes/bootInfo.ts
+++ b/server/routes/bootInfo.ts
@@ -1,0 +1,67 @@
+import { Router } from 'express'
+import { exec } from 'child_process'
+import { promisify } from 'util'
+
+const router = Router()
+const execAsync = promisify(exec)
+
+router.get('/api/system/boot-info', async (_req, res) => {
+  try {
+    const { stdout: bootOut } = await execAsync('findmnt /boot -n -o SOURCE')
+    const { stdout: rootOut } = await execAsync('findmnt / -n -o SOURCE')
+
+    const { stdout: throttleOut } = await execAsync('/usr/bin/vcgencmd get_throttled', {
+      env: { ...process.env, PATH: `${process.env.PATH ?? ''}:/usr/bin` },
+    })
+    const throttleRaw = throttleOut.trim()
+    let undervoltage = false
+    const match = throttleRaw.match(/0x([0-9a-fA-F]+)/)
+    if (match) {
+      undervoltage = parseInt(match[1], 16) !== 0
+    }
+
+    const nvme = {
+      temp: null as string | null,
+      percentUsed: null as string | null,
+      powerCycles: null as number | null,
+      mediaErrors: null as number | null,
+      warningTempExceeded: null as number | null,
+    }
+    try {
+      const { stdout: nvmeOut } = await execAsync('sudo nvme smart-log /dev/nvme0')
+      for (const line of nvmeOut.split('\n')) {
+        const t = line.trim()
+        if (/^temperature\b/i.test(t)) {
+          const m = t.match(/temperature\s*:\s*(\S+)/i)
+          if (m) nvme.temp = m[1]
+        } else if (/^percentage[_ ]?used/i.test(t)) {
+          const m = t.match(/percentage[_ ]?used\s*:\s*(\d+%)/i)
+          if (m) nvme.percentUsed = m[1]
+        } else if (/^power_cycles/i.test(t)) {
+          const m = t.match(/power_cycles\s*:\s*(\d+)/i)
+          if (m) nvme.powerCycles = Number(m[1])
+        } else if (/^media_errors/i.test(t)) {
+          const m = t.match(/media_errors\s*:\s*(\d+)/i)
+          if (m) nvme.mediaErrors = Number(m[1])
+        } else if (/^warning temperature time/i.test(t)) {
+          const m = t.match(/warning temperature time\s*:\s*(\d+)/i)
+          if (m) nvme.warningTempExceeded = Number(m[1])
+        }
+      }
+    } catch (err) {
+      // ignore NVMe errors
+    }
+
+    res.json({
+      bootDevice: bootOut.trim(),
+      rootDevice: rootOut.trim(),
+      undervoltage,
+      throttleRaw,
+      nvme,
+    })
+  } catch (err: any) {
+    res.status(500).json({ error: 'Failed to retrieve boot info', details: err.message })
+  }
+})
+
+export default router

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -146,3 +146,17 @@ export type InsertUser = z.infer<typeof insertUserSchema>;
 export type User = typeof users.$inferSelect;
 export type Session = typeof sessions.$inferSelect;
 export type LoginData = z.infer<typeof loginSchema>;
+
+export interface BootInfo {
+  bootDevice: string;
+  rootDevice: string;
+  undervoltage: boolean;
+  throttleRaw: string;
+  nvme: {
+    temp: string | null;
+    percentUsed: string | null;
+    powerCycles: number | null;
+    mediaErrors: number | null;
+    warningTempExceeded: number | null;
+  };
+}


### PR DESCRIPTION
## Summary
- provide `/api/system/boot-info` to expose boot device, voltage state, and NVMe stats
- create BootDeviceBox, UnderVoltageBox and NvmeSmartBox widgets
- add BootInfoRow section to dashboard
- wire boot info widgets into SystemOverview
- define `BootInfo` type in shared schema

## Testing
- `npm run check` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_685f4e7518848322a275808cee1d0202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new section in the system overview displaying boot device, power supply status, and NVMe health metrics.
  * Introduced real-time updates (every 60 seconds) for boot and hardware status information.
  * Enhanced visibility into system undervoltage events and NVMe device health.

* **Bug Fixes**
  * None.

* **Documentation**
  * None.

* **Chores**
  * None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->