### PR TITLE
Fetch boot info once for widgets

### DIFF
--- a/client/src/components/boot-info-row.tsx
+++ b/client/src/components/boot-info-row.tsx
@@ -1,18 +1,53 @@
+import { useEffect, useState } from 'react'
 import { BootDeviceBox } from '@/components/widgets/BootDeviceBox'
 import { UnderVoltageBox } from '@/components/widgets/UnderVoltageBox'
 import { NvmeSmartBox } from '@/components/widgets/NvmeSmartBox'
 
+interface BootInfo {
+  bootDevice: string
+  rootDevice: string
+  undervoltage: boolean
+  throttleRaw: string
+  nvme: {
+    temp: string | null
+    percentUsed: string | null
+    powerCycles: number | null
+    mediaErrors: number | null
+    warningTempExceeded: number | null
+  }
+}
+
 export function BootInfoRow() {
+  const [bootInfo, setBootInfo] = useState<BootInfo | null>(null)
+
+  useEffect(() => {
+    const fetchInfo = async () => {
+      try {
+        const res = await fetch('/api/system/boot-info')
+        if (!res.ok) throw new Error('Failed to fetch boot info')
+        const data: BootInfo = await res.json()
+        setBootInfo(data)
+      } catch (err) {
+        console.error(err)
+      }
+    }
+    fetchInfo()
+  }, [])
+
+  if (!bootInfo) {
+    return <p className="text-muted">Loading boot information...</p>
+  }
+
   return (
     <div className="flex flex-wrap gap-6 mt-6 w-full">
       <div className="flex-1 min-w-[300px] max-w-[32%]">
-        <BootDeviceBox />
+        <BootDeviceBox bootDevice={bootInfo.bootDevice} rootDevice={bootInfo.rootDevice} />
       </div>
       <div className="flex-1 min-w-[300px] max-w-[32%]">
-        <UnderVoltageBox />
+        <UnderVoltageBox undervoltage={bootInfo.undervoltage} throttleRaw={bootInfo.throttleRaw} />
       </div>
       <div className="flex-1 min-w-[300px] max-w-[32%]">
-        <NvmeSmartBox />
+        <NvmeSmartBox nvme={bootInfo.nvme} />
       </div>
     </div>
   )

--- a/client/src/components/widgets/BootDeviceBox.tsx
+++ b/client/src/components/widgets/BootDeviceBox.tsx
@@ -1,18 +1,11 @@
-import { useQuery } from '@tanstack/react-query'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
-const fetchBootInfo = async () => {
-  const res = await fetch('/api/system/boot-info')
-  if (!res.ok) throw new Error('Failed to fetch')
-  return res.json()
+interface BootDeviceBoxProps {
+  bootDevice: string
+  rootDevice: string
 }
 
-export function BootDeviceBox() {
-  const { data, error, isLoading, refetch } = useQuery({
-    queryKey: ['boot-info'],
-    queryFn: fetchBootInfo,
-    refetchInterval: 60000,
-  })
+export function BootDeviceBox({ bootDevice, rootDevice }: BootDeviceBoxProps) {
 
   return (
     <Card className="bg-pi-card border-pi-border h-full">
@@ -20,15 +13,9 @@ export function BootDeviceBox() {
         <CardTitle className="text-lg">Boot Source</CardTitle>
       </CardHeader>
       <CardContent className="pt-0 text-sm">
-        {isLoading ? (
-          <p>Loading...</p>
-        ) : error || !data ? (
-          <p className="text-red-400">Unavailable</p>
-        ) : (
-          <p className="font-mono">
-            {data.bootDevice} → {data.rootDevice}
-          </p>
-        )}
+        <p className="font-mono">
+          {bootDevice} → {rootDevice}
+        </p>
       </CardContent>
     </Card>
   )

--- a/client/src/components/widgets/NvmeSmartBox.tsx
+++ b/client/src/components/widgets/NvmeSmartBox.tsx
@@ -1,18 +1,16 @@
-import { useQuery } from '@tanstack/react-query'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
-const fetchBootInfo = async () => {
-  const res = await fetch('/api/system/boot-info')
-  if (!res.ok) throw new Error('Failed to fetch')
-  return res.json()
+interface NvmeSmartBoxProps {
+  nvme: {
+    temp: string | null
+    percentUsed: string | null
+    powerCycles: number | null
+    mediaErrors: number | null
+    warningTempExceeded: number | null
+  }
 }
 
-export function NvmeSmartBox() {
-  const { data, error, isLoading } = useQuery({
-    queryKey: ['boot-info'],
-    queryFn: fetchBootInfo,
-    refetchInterval: 60000,
-  })
+export function NvmeSmartBox({ nvme }: NvmeSmartBoxProps) {
 
   return (
     <Card className="bg-pi-card border-pi-border h-full">
@@ -20,18 +18,12 @@ export function NvmeSmartBox() {
         <CardTitle className="text-lg">NVMe Health</CardTitle>
       </CardHeader>
       <CardContent className="pt-0 text-sm">
-        {isLoading ? (
-          <p>Loading...</p>
-        ) : error || !data ? (
-          <p className="text-red-400">Unavailable</p>
-        ) : (
-          <ul className="space-y-1">
-            <li>Temp: {data.nvme.temp}</li>
-            <li>Used: {data.nvme.percentUsed}</li>
-            <li>Power Cycles: {data.nvme.powerCycles}</li>
-            <li>Media Errors: {data.nvme.mediaErrors}</li>
-          </ul>
-        )}
+        <ul className="space-y-1">
+          <li>Temp: {nvme.temp}</li>
+          <li>Used: {nvme.percentUsed}</li>
+          <li>Power Cycles: {nvme.powerCycles}</li>
+          <li>Media Errors: {nvme.mediaErrors}</li>
+        </ul>
       </CardContent>
     </Card>
   )

--- a/client/src/components/widgets/UnderVoltageBox.tsx
+++ b/client/src/components/widgets/UnderVoltageBox.tsx
@@ -1,20 +1,12 @@
-import { useQuery } from '@tanstack/react-query'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
-const fetchBootInfo = async () => {
-  const res = await fetch('/api/system/boot-info')
-  if (!res.ok) throw new Error('Failed to fetch')
-  return res.json()
+interface UnderVoltageBoxProps {
+  undervoltage: boolean
+  throttleRaw: string
 }
 
-export function UnderVoltageBox() {
-  const { data, error, isLoading } = useQuery({
-    queryKey: ['boot-info'],
-    queryFn: fetchBootInfo,
-    refetchInterval: 60000,
-  })
-
-  const isWarning = data?.undervoltage
+export function UnderVoltageBox({ undervoltage, throttleRaw }: UnderVoltageBoxProps) {
+  const isWarning = undervoltage
 
   return (
     <Card className="bg-pi-card border-pi-border h-full">
@@ -22,18 +14,12 @@ export function UnderVoltageBox() {
         <CardTitle className="text-lg">Power Supply</CardTitle>
       </CardHeader>
       <CardContent className="pt-0 text-sm">
-        {isLoading ? (
-          <p>Loading...</p>
-        ) : error || !data ? (
-          <p className="text-red-400">Unavailable</p>
-        ) : (
-          <div>
-            <p className={isWarning ? 'text-red-400' : 'text-green-400'}>
-              {isWarning ? 'Undervoltage Detected' : 'Normal'}
-            </p>
-            <p className="text-xs text-gray-400">{data.throttleRaw}</p>
-          </div>
-        )}
+        <div>
+          <p className={isWarning ? 'text-red-400' : 'text-green-400'}>
+            {isWarning ? 'Undervoltage Detected' : 'Normal'}
+          </p>
+          <p className="text-xs text-gray-400">{throttleRaw}</p>
+        </div>
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
## Summary
- add BootInfoRow data fetching with BootInfo type
- convert BootDeviceBox, UnderVoltageBox and NvmeSmartBox to accept props instead of fetching
- wire BootInfoRow to pass boot info props to widgets

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' / 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_685f7dee28a8832283b3d1e0e1d74fe5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified several system information widgets to receive their data via props instead of fetching it internally.
  * Centralized data fetching for boot information in a parent component, improving loading state handling and error logging.
  * Enhanced type safety and clarity by introducing explicit interfaces for component props.
  * Improved user experience with clearer loading indicators and more consistent data presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->