### PR TITLE
Fix: Ensure PiDeck binds to port 5006 for dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "NODE_ENV=development tsx server/index.ts",
+    "dev": "PORT=5006 NODE_ENV=development tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "PORT=5006 NODE_ENV=production node dist/index.js",
     "check": "tsc",


### PR DESCRIPTION
Updated the 'dev' script in package.json to explicitly set PORT=5006. This ensures the application consistently uses port 5006 when run with `npm run dev`, aligning with production, Nginx, PM2, and Replit configurations. This addresses the issue where the application might have been running on port 3001 due to environment-specific PORT overrides not being correctly managed for the dev environment.