### PR TITLE
Fix pg import for ESM

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,4 +1,5 @@
-import { Pool } from "pg";
+import pkg from "pg";
+const { Pool } = pkg;
 import { users, sessions, type User, type InsertUser, type Session } from "@shared/schema";
 import dotenv from 'dotenv';
 


### PR DESCRIPTION
## Summary
- use CommonJS style import from `pg`

## Testing
- `npm run check` *(fails: cannot find type definition file for 'node')*
- `npm run build` *(fails: vite not found)*
- `npm start` *(fails: cannot find module 'dist/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_68688a4c6af883228ca31d9298250439