### PR TITLE
Add login link in header

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,7 +21,7 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
   }
 
   if (!isAuthenticated) {
-    return <Redirect to="/" />;
+    return <Redirect to="/login" />;
   }
 
   return <>{children}</>;
@@ -30,7 +30,8 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
 function Router() {
   return (
     <Switch>
-      <Route path="/" component={Login} />
+      <Route path="/login" component={Login} />
+      <Route path="/" component={() => <Redirect to="/login" />} />
       <Route path="/dashboard">
         <ProtectedRoute>
           <Dashboard />

--- a/client/src/hooks/use-auth.ts
+++ b/client/src/hooks/use-auth.ts
@@ -32,7 +32,7 @@ export function useAuth() {
     },
     onSuccess: () => {
       queryClient.clear();
-      setLocation("/");
+      setLocation("/login");
     },
   });
 

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useEffect, useRef } from "react";
 import { useAuth } from "@/hooks/use-auth";
+import { Link } from "wouter";
 import { useSystemData } from "@/hooks/use-system-data";
 import { useTheme } from "@/components/theme-provider";
 import { useToast } from "@/hooks/use-toast";
@@ -13,8 +14,9 @@ import {
   Server, 
   Sun, 
   Moon, 
-  RefreshCw, 
+  RefreshCw,
   LogOut,
+  LogIn,
   Activity,
   FileText,
   Grid,
@@ -39,7 +41,7 @@ interface TabDefinition {
 export default function Dashboard() {
   const [activeTab, setActiveTab] = useState<TabId>("dashboard");
   const [rebootRequired, setRebootRequired] = useState(false);
-  const { logout, isLogoutPending } = useAuth();
+  const { logout, isLogoutPending, isAuthenticated } = useAuth();
   const { systemInfo, systemAlerts, refreshAll, updateSystem, isSystemUpdating } = useSystemData();
   const { theme, setTheme } = useTheme();
   const { toast } = useToast();
@@ -189,16 +191,28 @@ export default function Dashboard() {
                 <RefreshCw className={`w-5 h-5 ${systemInfo.isLoading ? 'animate-spin' : ''}`} />
               </Button>
               
-              {/* Logout */}
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleLogout}
-                disabled={isLogoutPending}
-                className="p-2 bg-transparent hover:bg-pi-card-hover border-pi-border text-pi-error hover:text-pi-error"
-              >
-                <LogOut className="w-5 h-5" />
-              </Button>
+              {/* Auth Button */}
+              {isAuthenticated ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleLogout}
+                  disabled={isLogoutPending}
+                  className="p-2 bg-transparent hover:bg-pi-card-hover border-pi-border text-pi-error hover:text-pi-error"
+                >
+                  <LogOut className="w-5 h-5" />
+                </Button>
+              ) : (
+                <Link href="/login">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="p-2 bg-transparent hover:bg-pi-card-hover border-pi-border"
+                  >
+                    <LogIn className="w-5 h-5" />
+                  </Button>
+                </Link>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add dedicated /login route and redirect root there
- update logout to send users back to /login
- show login icon in dashboard header when unauthenticated

## Testing
- `npm run check` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_686890294dec8322b3facbe24e36fa85