### PR TITLE
Fix login icon and normalize timestamps

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -16,12 +16,12 @@ import {
   Moon,
   RefreshCw,
   LogOut,
-  Lock,
+  LogIn,
   Activity,
   FileText,
   Grid,
   Clock,
-  SettingsIcon // Added SettingsIcon
+  SettingsIcon,
 } from "lucide-react";
 
 // Forward ref for components used in tabs
@@ -176,17 +176,6 @@ export default function Dashboard() {
                 )}
               </Button>
               
-              {/* Refresh */}
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={refreshAll}
-                className="p-2 bg-transparent hover:bg-pi-card-hover border-pi-border"
-                disabled={systemInfo.isLoading}
-              >
-                <RefreshCw className={`w-5 h-5 ${systemInfo.isLoading ? 'animate-spin' : ''}`} />
-              </Button>
-              
               {/* Auth Button */}
               {isAuthenticated ? (
                 <Button
@@ -205,10 +194,21 @@ export default function Dashboard() {
                     className="ml-2"
                     aria-label="Login"
                   >
-                    <Lock className="w-5 h-5" />
+                    <LogIn className="w-5 h-5" />
                   </Button>
                 </Link>
               )}
+
+              {/* Refresh */}
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={refreshAll}
+                className="p-2 bg-transparent hover:bg-pi-card-hover border-pi-border"
+                disabled={systemInfo.isLoading}
+              >
+                <RefreshCw className={`w-5 h-5 ${systemInfo.isLoading ? 'animate-spin' : ''}`} />
+              </Button>
             </div>
           </div>
         </div>

--- a/server/services/system.ts
+++ b/server/services/system.ts
@@ -31,7 +31,7 @@ let previousDiskStats: { read: number; write: number; timestamp: number } | null
 interface ActiveAlert {
   id: string;
   message: string;
-  timestamp: Date;
+  timestamp: string;
   type: 'temperature'; // Can be expanded later
 }
 let activeAlerts: ActiveAlert[] = [];
@@ -93,7 +93,7 @@ export class SystemService {
         const newAlert: ActiveAlert = {
           id: `temp-${Date.now()}`,
           message: `Temperature exceeded ${TEMPERATURE_THRESHOLD}°C: Currently ${currentTemperature.toFixed(1)}°C`,
-          timestamp: new Date(),
+          timestamp: new Date().toISOString(),
           type: 'temperature',
         };
         activeAlerts.push(newAlert);
@@ -101,7 +101,7 @@ export class SystemService {
       } else {
         // Optionally update the existing alert message or timestamp if it's still active
         existingAlert.message = `Temperature remains above ${TEMPERATURE_THRESHOLD}°C: Currently ${currentTemperature.toFixed(1)}°C`;
-        existingAlert.timestamp = new Date();
+        existingAlert.timestamp = new Date().toISOString();
       }
     } else {
       if (existingAlert) {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -138,7 +138,7 @@ export interface SystemInfo extends Omit<SystemInfoExtended, 'diskIO' | 'network
 export interface ActiveAlert {
   id: string;
   message: string;
-  timestamp: Date;
+  timestamp: string;
   type: 'temperature';
 }
 


### PR DESCRIPTION
## Summary
- add LogIn icon and move auth button next to theme toggle
- keep login/logout icons imported cleanly
- store active alert timestamps as ISO strings

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node', 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68689a18df0883229bf6c5ec9bca1802