### PR TITLE
Add password change page and timestamp fix

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { useAuth } from "@/hooks/use-auth";
 import Login from "@/pages/login";
 import Dashboard from "@/pages/dashboard";
+import ChangePassword from "@/pages/change-password";
 import NotFound from "@/pages/not-found";
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
@@ -32,6 +33,11 @@ function Router() {
     <Switch>
       <Route path="/login" component={Login} />
       <Route path="/" component={() => <Redirect to="/login" />} />
+      <Route path="/change-password">
+        <ProtectedRoute>
+          <ChangePassword />
+        </ProtectedRoute>
+      </Route>
       <Route path="/dashboard">
         <ProtectedRoute>
           <Dashboard />

--- a/client/src/hooks/use-auth.ts
+++ b/client/src/hooks/use-auth.ts
@@ -39,7 +39,7 @@ export function useAuth() {
   const changePasswordMutation = useMutation({
     mutationFn: async (data: { currentPassword?: string; newPassword?: string; confirmNewPassword?: string }) => {
       // The backend expects currentPassword and newPassword. confirmNewPassword is for client-side validation.
-      return apiRequest("POST", "/api/user/change-password", {
+      return apiRequest("POST", "/api/auth/change-password", {
         currentPassword: data.currentPassword,
         newPassword: data.newPassword,
         confirmNewPassword: data.confirmNewPassword, // Send it for Zod validation on backend too

--- a/client/src/pages/change-password.tsx
+++ b/client/src/pages/change-password.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import { Link } from "wouter";
+import { useAuth } from "@/hooks/use-auth";
+import { useToast } from "@/hooks/use-toast";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Server } from "lucide-react";
+
+export default function ChangePassword() {
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmNewPassword, setConfirmNewPassword] = useState("");
+  const { changePassword, isChangingPassword } = useAuth();
+  const { toast } = useToast();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!currentPassword || !newPassword || !confirmNewPassword) {
+      toast({
+        title: "Error",
+        description: "All fields are required",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (newPassword !== confirmNewPassword) {
+      toast({
+        title: "Error",
+        description: "New passwords do not match",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    try {
+      await changePassword({ currentPassword, newPassword, confirmNewPassword });
+      toast({ title: "Success", description: "Password changed successfully" });
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmNewPassword("");
+    } catch (error: any) {
+      toast({
+        title: "Error",
+        description: error?.message || "Failed to change password",
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-pi-darker to-pi-dark">
+      <div className="max-w-md w-full mx-4">
+        <Card className="bg-pi-card border-pi-border shadow-2xl">
+          <CardContent className="p-8">
+            <div className="text-center mb-8">
+              <div className="flex items-center justify-center mb-4">
+                <div className="w-12 h-12 bg-pi-accent rounded-lg flex items-center justify-center">
+                  <Server className="w-6 h-6 text-white" />
+                </div>
+              </div>
+              <Link href="/dashboard">
+                <h1 className="text-2xl font-bold cursor-pointer hover:text-primary pi-text mb-2">PiDeck</h1>
+              </Link>
+              <p className="pi-text-muted">Change Password</p>
+            </div>
+            <form onSubmit={handleSubmit} className="space-y-6">
+              <div>
+                <Label className="block text-sm font-medium pi-text-muted mb-2">Current Password</Label>
+                <Input
+                  type="password"
+                  value={currentPassword}
+                  onChange={(e) => setCurrentPassword(e.target.value)}
+                  className="w-full px-4 py-3 bg-pi-darker border-pi-border pi-text placeholder:pi-text-muted focus:ring-2 focus:ring-pi-accent focus:border-transparent"
+                />
+              </div>
+              <div>
+                <Label className="block text-sm font-medium pi-text-muted mb-2">New Password</Label>
+                <Input
+                  type="password"
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  className="w-full px-4 py-3 bg-pi-darker border-pi-border pi-text placeholder:pi-text-muted focus:ring-2 focus:ring-pi-accent focus:border-transparent"
+                />
+              </div>
+              <div>
+                <Label className="block text-sm font-medium pi-text-muted mb-2">Confirm New Password</Label>
+                <Input
+                  type="password"
+                  value={confirmNewPassword}
+                  onChange={(e) => setConfirmNewPassword(e.target.value)}
+                  className="w-full px-4 py-3 bg-pi-darker border-pi-border pi-text placeholder:pi-text-muted focus:ring-2 focus:ring-pi-accent focus:border-transparent"
+                />
+              </div>
+              <Button
+                type="submit"
+                className="w-full pi-accent hover:bg-blue-600 text-white font-semibold py-3 px-4 transition-colors duration-200"
+                disabled={isChangingPassword}
+              >
+                {isChangingPassword ? "Updating..." : "Update Password"}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -142,7 +142,9 @@ export default function Dashboard() {
                 <Server className="w-5 h-5 text-white" />
               </div>
               <div>
-                <h1 className="text-xl font-bold pi-text">PiDeck</h1>
+                <Link href="/dashboard">
+                  <h1 className="text-xl font-bold pi-text cursor-pointer hover:text-primary">PiDeck</h1>
+                </Link>
                 <p className="text-sm pi-text-muted">Raspberry Pi Admin</p>
               </div>
             </div>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -119,8 +119,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  // User routes (for things like password change)
-  app.post("/api/user/change-password", requireAuth, async (req: any, res: any) => {
+  // Password change route
+  app.post("/api/auth/change-password", requireAuth, async (req: any, res: any) => {
     try {
       const { currentPassword, newPassword } = passwordChangeSchema.parse(req.body);
       const userId = req.session.userId;
@@ -160,7 +160,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       // Optional: Re-issue session or update session details if needed, though often not necessary for password change.
       // Forcing logout on other devices is a more advanced feature.
 
-      console.log(`[API /user/change-password] User ${user.username} (ID: ${userId}) changed their password successfully.`);
+      console.log(`[API /auth/change-password] User ${user.username} (ID: ${userId}) changed their password successfully.`);
       res.json({ message: "Password changed successfully." });
 
     } catch (error) {

--- a/server/services/system.ts
+++ b/server/services/system.ts
@@ -239,7 +239,7 @@ private static async getNetworkBandwidth(): Promise<NetworkBandwidth> {
   private static async logHistoricalData(data: SystemInfo): Promise<void> {
     try {
         const metricRecord: InsertHistoricalMetric = {
-          timestamp: new Date().toISOString(), // store as ISO string
+          timestamp: new Date(), // ensure Date instance for PgTimestamp
           cpuUsage: Math.round(data.cpu ?? 0),
           memoryUsage: Math.round(data.memory?.percentage ?? 0),
           temperature: Math.round(data.temperature ?? 0),
@@ -251,7 +251,7 @@ private static async getNetworkBandwidth(): Promise<NetworkBandwidth> {
       await db.insert(historicalMetrics).values(metricRecord);
 
       // Prune old data (older than 24 hours)
-      const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+      const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
       await db.delete(historicalMetrics).where(sql`${historicalMetrics.timestamp} < ${twentyFourHoursAgo}`);
 
     } catch (error) {
@@ -261,7 +261,7 @@ private static async getNetworkBandwidth(): Promise<NetworkBandwidth> {
 
   static async getHistoricalData(): Promise<HistoricalMetric[]> {
     try {
-      const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+      const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
       return await db.select().from(historicalMetrics)
         .where(sql`${historicalMetrics.timestamp} >= ${twentyFourHoursAgo}`)
         .orderBy(historicalMetrics.timestamp);


### PR DESCRIPTION
## Summary
- create `/change-password` route with a new page
- make PiDeck header link back to dashboard
- update hook and backend route for password change
- ensure timestamps use `Date` objects for logging

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6868a43b49ec8322ac9720fee2d00fa1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated change password page accessible only to authenticated users.
  * Added a user interface for changing passwords, including validation and feedback notifications.

* **Improvements**
  * Updated password change API endpoint for consistency.
  * Enhanced navigation by making the dashboard heading clickable.

* **Bug Fixes**
  * Improved timestamp handling for historical data to ensure more accurate data logging and retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->