### PR TITLE
Fix timestamp insertion

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -95,7 +95,8 @@ export type ProcessInfo = {
 // Historical data table
 export const historicalMetrics = pgTable("historical_metrics", {
   id: serial("id").primaryKey(),
-  timestamp: timestamp("timestamp").notNull().defaultNow(),
+  // store timestamp as ISO string for postgres.js compatibility
+  timestamp: timestamp("timestamp", { mode: 'string' }).notNull().defaultNow(),
   cpuUsage: integer("cpu_usage"),
   memoryUsage: integer("memory_usage"), // Percentage
   temperature: integer("temperature"),


### PR DESCRIPTION
## Summary
- store historical metric timestamps as strings
- convert Date objects to ISO strings before DB insertion

## Testing
- `npx drizzle-kit push` *(fails: 403 Forbidden due to restricted network)*
- `npm run check` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6868cb1c1ccc83228411ee84809ab0cf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in timestamp handling for historical metrics, ensuring all timestamps are stored and compared as ISO strings.
  * Enhanced compatibility with database systems by updating the storage format of timestamps.

* **Chores**
  * Added logging to confirm successful insertion of historical metric records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->