### PR TITLE
Fix: Ensure dashboard header link resets state

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useEffect, useRef } from "react";
 import { useAuth } from "@/hooks/use-auth";
-import { Link } from "wouter";
+import { Link, useLocation } from "wouter";
 import { useSystemData } from "@/hooks/use-system-data";
 import { useTheme } from "@/components/theme-provider";
 import { useToast } from "@/hooks/use-toast";
@@ -48,6 +48,13 @@ export default function Dashboard() {
   const { theme, setTheme } = useTheme();
   const { toast } = useToast();
   const displayedAlertIds = useRef<Set<string>>(new Set());
+  const [location, navigate] = useLocation();
+
+  useEffect(() => {
+    if (location === "/dashboard") {
+      setActiveTab("dashboard");
+    }
+  }, [location]);
 
   useEffect(() => {
     fetch("/api/reboot-check", { credentials: "include" })
@@ -144,9 +151,15 @@ export default function Dashboard() {
                 <Server className="w-5 h-5 text-white" />
               </div>
               <div>
-                <Link href="/dashboard">
-                  <h1 className="text-xl font-bold pi-text cursor-pointer hover:text-primary">PiDeck</h1>
-                </Link>
+                <h1
+                  onClick={() => {
+                    setActiveTab("dashboard"); // Reset active tab
+                    navigate("/dashboard", { replace: true }); // Force re-navigation
+                  }}
+                  className="text-xl font-bold pi-text cursor-pointer hover:text-primary"
+                >
+                  PiDeck
+                </h1>
                 <p className="text-sm pi-text-muted">Raspberry Pi Admin</p>
               </div>
             </div>


### PR DESCRIPTION
The PiDeck header link in the dashboard now correctly resets the activeTab to 'dashboard' and forces a re-navigation to /dashboard when clicked, even if the user is already on that page.

Additionally, a useEffect hook has been added to ensure that if a user lands directly on /dashboard (e.g., via bookmark or direct URL entry), the activeTab is also reset to 'dashboard'.