### PR TITLE
Add About modal and align logout

### DIFF
--- a/client/src/components/modals/about-modal.tsx
+++ b/client/src/components/modals/about-modal.tsx
@@ -1,0 +1,70 @@
+import { Info } from "lucide-react";
+import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+
+export default function AboutModal() {
+  return (
+    <Dialog>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DialogTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              className="p-2 bg-transparent hover:bg-pi-card-hover border-pi-border"
+              aria-label="About PiDeck"
+            >
+              <Info className="w-5 h-5" />
+            </Button>
+          </DialogTrigger>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>About PiDeck</p>
+        </TooltipContent>
+      </Tooltip>
+      <DialogContent className="p-6 sm:rounded-xl">
+        <DialogHeader>
+          <DialogTitle>About PiDeck</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 text-sm">
+          <div>
+            <h2 className="font-bold mb-1">Tech Stack</h2>
+            <ul className="list-disc list-inside space-y-1">
+              <li>Backend: Node.js, Express.js, TypeScript</li>
+              <li>Shell Integration: child_process</li>
+              <li>Frontend: React 18, Vite, TypeScript</li>
+              <li>Styling: TailwindCSS, Shadcn/ui</li>
+              <li>State Management: TanStack Query</li>
+              <li>Routing: Wouter</li>
+              <li>Database: PostgreSQL + Drizzle ORM</li>
+              <li>Auth: Session-based authentication</li>
+            </ul>
+          </div>
+          <div>
+            <h2 className="font-bold mb-1">Contact</h2>
+            <p>Author: 0xWulf</p>
+            <p>
+              Email: <a href="mailto:dev@0xwulf.dev" className="underline">dev@0xwulf.dev</a>
+            </p>
+          </div>
+          <div>
+            <h2 className="font-bold mb-1">GitHub Repo</h2>
+            <a
+              href="https://github.com/hexawulf/PiDeck"
+              className="underline break-all"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              https://github.com/hexawulf/PiDeck
+            </a>
+          </div>
+          <div>
+            <p>Version: v1.0.0</p>
+            <p>Release Date: June 2025</p>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -17,6 +17,7 @@ import {
   RefreshCw,
   LogOut,
   LogIn,
+  Info,
   Activity,
   FileText,
   Grid,
@@ -25,6 +26,8 @@ import {
   KeySquare, // Using KeySquare as KeyIcon is often a generic key
 } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"; // Moved import here
+
+import AboutModal from "@/components/modals/about-modal";
 
 // Forward ref for components used in tabs
 import React from 'react'; // Already here, but good to note
@@ -179,6 +182,9 @@ export default function Dashboard() {
 
             {/* Actions */}
             <div className="flex items-center space-x-3">
+              {/* About Modal */}
+              <AboutModal />
+
               {/* Theme Toggle */}
               <Button
                 variant="outline"
@@ -214,29 +220,6 @@ export default function Dashboard() {
                 </Tooltip>
               )}
               
-              {/* Auth Button */}
-              {isAuthenticated ? (
-                <Button
-                  variant="ghost"
-                  onClick={() => logout()}
-                  className="ml-2"
-                  aria-label="Logout"
-                  disabled={isLogoutPending}
-                >
-                  <LogOut className="w-5 h-5" />
-                </Button>
-              ) : (
-                <Link href="/login">
-                  <Button
-                    variant="ghost"
-                    className="ml-2"
-                    aria-label="Login"
-                  >
-                    <LogIn className="w-5 h-5" />
-                  </Button>
-                </Link>
-              )}
-
               {/* Refresh */}
               <Button
                 variant="outline"
@@ -247,6 +230,29 @@ export default function Dashboard() {
               >
                 <RefreshCw className={`w-5 h-5 ${systemInfo.isLoading ? 'animate-spin' : ''}`} />
               </Button>
+
+              {/* Auth Button */}
+              {isAuthenticated ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => logout()}
+                  aria-label="Logout"
+                  className="p-2 bg-transparent hover:bg-pi-card-hover border-pi-border"
+                  disabled={isLogoutPending}
+                >
+                  <LogOut className="w-5 h-5" />
+                </Button>
+              ) : (
+                <Link href="/login">
+                  <Button
+                    variant="ghost"
+                    aria-label="Login"
+                  >
+                    <LogIn className="w-5 h-5" />
+                  </Button>
+                </Link>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add `AboutModal` component
- insert info button and show about modal
- reposition logout button to rightmost and match header style

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node', 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_686c50e462d48322b28351ecde82d47a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "About" modal accessible from the dashboard header, providing details on the app's tech stack, contact information, GitHub link, and version info.

* **Style**
  * Updated the appearance and layout of dashboard header action buttons for improved consistency and usability.
  * Reordered action buttons in the dashboard header for a more intuitive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->