### PR TITLE
Fix: Restore Replit Plugin Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,8 @@
         "zod-validation-error": "^3.4.0"
       },
       "devDependencies": {
+        "@replit/vite-plugin-cartographer": "^0.2.7",
+        "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
         "@tailwindcss/typography": "^0.5.15",
         "@tailwindcss/vite": "^4.1.3",
         "@types/connect-pg-simple": "^7.0.3",
@@ -2901,6 +2903,28 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
+    },
+    "node_modules/@replit/vite-plugin-cartographer": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@replit/vite-plugin-cartographer/-/vite-plugin-cartographer-0.2.7.tgz",
+      "integrity": "sha512-EkHYIRXKizytI+d1ljrD6yyG3I/uA5NdFWX+Ytx0cCTIZigjiictMBLnLOLH5ndAmWfWAD83cmXeWsFld7gdEA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.26.9",
+        "@babel/traverse": "^7.26.9",
+        "@babel/types": "^7.26.9",
+        "magic-string": "^0.30.12",
+        "modern-screenshot": "^4.6.0"
+      }
+    },
+    "node_modules/@replit/vite-plugin-runtime-error-modal": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@replit/vite-plugin-runtime-error-modal/-/vite-plugin-runtime-error-modal-0.0.3.tgz",
+      "integrity": "sha512-4wZHGuI9W4o9p8g4Ma/qj++7SP015+FMDGYobj7iap5oEsxXMm0B02TO5Y5PW8eqBPd4wX5l3UGco/hlC0qapw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.19",
@@ -6620,6 +6644,13 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/modern-screenshot": {
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/modern-screenshot/-/modern-screenshot-4.6.5.tgz",
+      "integrity": "sha512-0sDePJ9ssXWDO7V+yW9lwAxAu8jmVp4CXlBbjskSqrDxkIrcZO2EGqwD2mLtfTTinqZjmP4X/V6INOvNM1K7CQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/motion-dom": {
       "version": "11.18.1",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,8 @@
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
+    "@replit/vite-plugin-cartographer": "^0.2.7",
+    "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
     "@tailwindcss/typography": "^0.5.15",
     "@tailwindcss/vite": "^4.1.3",
     "@types/connect-pg-simple": "^7.0.3",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,22 +1,29 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
-import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
+import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal"; // Always import this
 
-export default defineConfig({
-  plugins: [
+// Export an async function to enable dynamic imports for plugins
+export default defineConfig(async () => {
+  const plugins = [
     react(),
-    runtimeErrorOverlay(),
-    ...(process.env.NODE_ENV !== "production" &&
-    process.env.REPL_ID !== undefined
-      ? [
-          await import("@replit/vite-plugin-cartographer").then((m) =>
-            m.cartographer(),
-          ),
-        ]
-      : []),
-  ],
-  resolve: {
+    runtimeErrorOverlay(), // Always include this plugin
+  ];
+
+  // Conditionally load @replit/vite-plugin-cartographer
+  if (process.env.NODE_ENV !== "production" && process.env.REPL_ID) {
+    try {
+      const { cartographer } = await import("@replit/vite-plugin-cartographer");
+      plugins.push(cartographer());
+    } catch (error) {
+      console.warn("Failed to load @replit/vite-plugin-cartographer:", error);
+      // Optionally, inform the user or proceed without it if it's non-critical
+    }
+  }
+
+  return {
+    plugins,
+    resolve: {
     alias: {
       "@": path.resolve(import.meta.dirname, "client", "src"),
       "@shared": path.resolve(import.meta.dirname, "shared"),


### PR DESCRIPTION
This commit restores Replit plugin support for compatibility with Replit-based development environments.

Changes include:
- Added `@replit/vite-plugin-runtime-error-modal` and `@replit/vite-plugin-cartographer` back to devDependencies in `package.json`.
- Updated `vite.config.ts` to:
  - Export an async configuration function.
  - Always import and include `@replit/vite-plugin-runtime-error-modal`.
  - Conditionally and dynamically import `@replit/vite-plugin-cartographer` (with try/catch) when `NODE_ENV !== 'production'` and `REPL_ID` is defined.
- Ran `npm install` to update `package-lock.json`.

This ensures that Vite behaves correctly with dynamic imports and that the necessary Replit plugins are available in the appropriate environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to include new plugins for enhanced development experience.
  * Improved the build configuration to handle plugin loading more flexibly and robustly during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->