### PR TITLE
Fix: Include credentials in log viewer fetch calls

### DIFF
--- a/client/src/components/log-viewer.tsx
+++ b/client/src/components/log-viewer.tsx
@@ -81,7 +81,7 @@ export default function LogViewer() {
     const fetchLogContents = async () => {
       if (logFilesQuery.data) {
         const promises = logFilesQuery.data.map(async (logFile) => {
-          const res = await fetch(`/api/logs/${encodeURIComponent(logFile.name)}`);
+          const res = await fetch(`/api/logs/${encodeURIComponent(logFile.name)}`, { credentials: "include" });
           const data = await res.json();
           return {
             filename: logFile.name,


### PR DESCRIPTION
The log viewer component was failing to display log files because the fetch calls to retrieve log content were missing authentication credentials. This resulted in 401 Unauthorized responses from the API.

This change adds `credentials: "include"` to the fetch options, ensuring that session cookies are sent with the request. This resolves the authentication issue and allows the log content to be fetched and displayed correctly.