### PR TITLE
feat: Fix PiDeck logs and add compatibility aliases

### DIFF
--- a/jules-scratch/verification/verify_log_viewer.py
+++ b/jules-scratch/verification/verify_log_viewer.py
@@ -1,0 +1,23 @@
+import asyncio
+from playwright.async_api import async_playwright, expect
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page()
+
+        # The application is running on port 5006
+        await page.goto("http://localhost:5006")
+
+        # Wait for the log viewer to be visible
+        await expect(page.get_by_text("Logs")).to_be_visible()
+        await page.screenshot(path="jules-scratch/verification/log-viewer-initial.png")
+
+        # Click on the first log file
+        await page.get_by_role("button").first.click()
+        await page.screenshot(path="jules-scratch/verification/log-viewer-with-content.png")
+
+        await browser.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "date-fns": "^3.6.0",
         "dockerode": "^4.0.9",
         "dotenv": "^16.5.0",
+        "dotenv-cli": "^10.0.0",
         "drizzle-orm": "^0.39.1",
         "drizzle-zod": "^0.7.0",
         "embla-carousel-react": "^8.6.0",
@@ -5516,6 +5517,48 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dotenv-cli": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-10.0.0.tgz",
+      "integrity": "sha512-lnOnttzfrzkRx2echxJHQRB6vOAMSCzzZg79IxpC00tU42wZPuZkQxNNrrwVAxaQZIIh001l4PxVlCrBxngBzA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "dotenv": "^17.1.0",
+        "dotenv-expand": "^11.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-cli/node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+      "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/drizzle-kit": {
       "version": "0.30.6",
       "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.30.6.tgz",
@@ -7727,6 +7770,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "PORT=5006 NODE_ENV=development tsx server/index.ts",
+    "dev": "dotenv -e .env -- tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "PORT=5006 NODE_ENV=production node dist/index.js",
     "check": "tsc",
@@ -52,6 +52,7 @@
     "date-fns": "^3.6.0",
     "dockerode": "^4.0.9",
     "dotenv": "^16.5.0",
+    "dotenv-cli": "^10.0.0",
     "drizzle-orm": "^0.39.1",
     "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.6.0",

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,6 +11,8 @@ import memoryRoute from "./routes/memory";
 import topProcessesRoute from "./routes/topProcesses";
 import networkRoute from "./routes/network";
 import firewallRoute from "./routes/firewall";
+import rasplogsRouter from "./routes/rasplogs";
+import compatRouter from "./routes/compat";
 
 const app = express();
 app.use(express.json());
@@ -24,6 +26,8 @@ app.use(memoryRoute);
 app.use(topProcessesRoute);
 app.use(networkRoute);
 app.use(firewallRoute);
+app.use("/api", rasplogsRouter);
+app.use("/api", compatRouter);
 
 app.use((req, res, next) => {
   const start = Date.now();

--- a/server/routes/compat.ts
+++ b/server/routes/compat.ts
@@ -1,0 +1,22 @@
+import { Router } from "express";
+
+const compatRouter = Router();
+
+// Alias /api/hostlogs and /api/logs to /api/rasplogs
+compatRouter.get(["/hostlogs", "/logs"], (_req, res) => {
+  res.redirect(301, "/api/rasplogs");
+});
+
+// Alias /api/hostlogs/:name to /api/rasplogs/:name
+compatRouter.get("/hostlogs/:name", (req, res) => {
+  const { name } = req.params;
+  const query = req.url.split("?")[1];
+  res.redirect(301, `/api/rasplogs/${name}${query ? `?${query}` : ""}`);
+});
+
+// Alias /api/system/alerts to return an empty array
+compatRouter.get("/system/alerts", (_req, res) => {
+  res.json([]);
+});
+
+export default compatRouter;

--- a/server/routes/rasplogs.ts
+++ b/server/routes/rasplogs.ts
@@ -1,0 +1,141 @@
+import { Router } from "express";
+import { readdir, stat, realpath } from "fs/promises";
+import { resolve, basename } from "path";
+import { spawn } from "child_process";
+import type { LogIndexEntry } from "@shared/schema";
+
+const rasplogsRouter = Router();
+const LOGS_DIR = "/home/zk/logs";
+const MAX_FILE_SIZE_BYTES = 20 * 1024 * 1024; // 20 MiB
+
+const ALLOWED_EXTENSIONS = [".log", ".txt", ".journal"];
+const IGNORED_PATTERNS = [/\.gz$/, /\.tar\.gz$/, /\.zip$/];
+
+// Function to safely check real paths
+async function isPathSafe(filePath: string): Promise<boolean> {
+  try {
+    const resolved = await realpath(filePath);
+    return resolved.startsWith(LOGS_DIR);
+  } catch (err) {
+    return false; // File does not exist or other error
+  }
+}
+
+// GET /api/rasplogs -> list log files
+rasplogsRouter.get("/rasplogs", async (_req, res) => {
+  try {
+    const dirents = await readdir(LOGS_DIR, { withFileTypes: true });
+    const logEntries: LogIndexEntry[] = [];
+
+    for (const dirent of dirents) {
+      if (dirent.isDirectory()) continue;
+
+      const fileName = dirent.name;
+      const fileExt = basename(fileName);
+
+      if (
+        !ALLOWED_EXTENSIONS.some((ext) => fileName.endsWith(ext)) ||
+        IGNORED_PATTERNS.some((pattern) => pattern.test(fileName))
+      ) {
+        continue;
+      }
+
+      const filePath = resolve(LOGS_DIR, fileName);
+      if (!(await isPathSafe(filePath))) continue;
+
+      const stats = await stat(filePath);
+      logEntries.push({
+        id: fileName,
+        name: fileName,
+        label: fileName,
+        path: filePath,
+        size: stats.size,
+        mtime: stats.mtime.toISOString(),
+        pathExists: true,
+        tooLarge: stats.size > MAX_FILE_SIZE_BYTES,
+      });
+    }
+
+    // Sort by modification time, newest first
+    logEntries.sort((a, b) => new Date(b.mtime).getTime() - new Date(a.mtime).getTime());
+
+    res.json(logEntries);
+  } catch (error) {
+    console.error("Error listing rasplogs:", error);
+    res.status(500).json({ message: "Failed to list log files." });
+  }
+});
+
+// GET /api/rasplogs/:name -> tail/stream a log file
+rasplogsRouter.get("/rasplogs/:name", async (req, res) => {
+  const { name } = req.params;
+  const { tail = "1000", grep, follow } = req.query;
+
+  const filePath = resolve(LOGS_DIR, name);
+
+  if (!(await isPathSafe(filePath))) {
+    return res.status(403).json({ message: "Forbidden: Access outside of log directory is not allowed." });
+  }
+
+  try {
+    await stat(filePath);
+  } catch (err) {
+    return res.status(404).json({ message: "Log file not found." });
+  }
+
+  if (follow === "1") {
+    // SSE streaming
+    res.setHeader("Content-Type", "text/event-stream");
+    res.setHeader("Cache-Control", "no-cache");
+    res.setHeader("Connection", "keep-alive");
+    res.flushHeaders();
+
+    const tailCommand = ["-n", tail as string, "-F", filePath];
+    const tailProc = spawn("tail", tailCommand);
+
+    let stream: NodeJS.ReadableStream = tailProc.stdout;
+
+    if (grep) {
+      const grepProc = spawn("grep", [grep as string]);
+      tailProc.stdout.pipe(grepProc.stdin);
+      stream = grepProc.stdout;
+    }
+
+    const onData = (data: Buffer) => {
+      const lines = data.toString().split("\n").filter(Boolean);
+      for (const line of lines) {
+        res.write(`data: ${JSON.stringify({ line })}\n\n`);
+      }
+    };
+
+    stream.on("data", onData);
+
+    req.on("close", () => {
+      stream.removeListener("data", onData);
+      tailProc.kill();
+    });
+  } else {
+    // Snapshot
+    const args = ["-n", tail as string];
+    let child;
+
+    if (grep) {
+      const grepProc = spawn("grep", [grep as string, filePath]);
+      child = spawn("tail", args, { stdio: [grepProc.stdout, "pipe", "pipe"] });
+    } else {
+      args.push(filePath);
+      child = spawn("tail", args);
+    }
+
+    let output = "";
+    child.stdout.on("data", (data) => {
+      output += data.toString();
+    });
+
+    child.on("close", () => {
+      res.json({ content: output });
+    });
+  }
+});
+
+export default rasplogsRouter;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -33,12 +33,48 @@ export type LogFile = {
   content?: string;
 };
 
+export const logIndexEntrySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  label: z.string(),
+  path: z.string(),
+  size: z.number(),
+  mtime: z.string(),
+  pathExists: z.boolean(),
+  tooLarge: z.boolean(),
+});
+
+export type LogIndexEntry = z.infer<typeof logIndexEntrySchema>;
+
+// Keep legacy types for now to avoid breaking changes during migration
+export type HostLog = {
+  id: string;
+  label: string;
+  pathExists: boolean;
+};
+
+export type RpiLog = {
+  id: string;
+  label: string;
+  path: string;
+  relPath: string;
+  size: number;
+  mtime: string;
+  pathExists: boolean;
+  tooLarge: boolean;
+};
+
 export type DockerContainer = {
   id: string;
   name: string;
   image: string;
   status: string;
   state: string;
+};
+
+export type DockerContainersResponse = {
+  containers: DockerContainer[];
+  warning?: string;
 };
 
 export type PM2Process = {


### PR DESCRIPTION
This commit fixes the logs pane in the PiDeck application, which was previously empty and causing 404 errors.

- Implemented a new canonical API at `/api/rasplogs` to read and stream logs from the `/home/zk/logs` directory.
- Added compatibility aliases for legacy endpoints (`/api/hostlogs`, `/api/logs`, `/api/system/alerts`) to prevent 404 errors during the frontend migration.
- Updated the frontend log viewer to use the new API, simplifying the UI and removing the distinction between "host" and "rpi" logs.
- Refactored the `useSystemData` hook to remove legacy log-related code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Unified log viewer consolidating all log types into a single interface with consistent labeling.
* Automatic log refresh every 30 seconds for real-time updates.
* Simplified log following with streamlined UI controls.

**Bug Fixes & Improvements**
* Centralized log filtering and search functionality.
* Enhanced error handling and standardized messaging.
* Improved compatibility with legacy log endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->